### PR TITLE
[plan][feat]: add missing target/draft model JSONs — opt-6.7b, llama2-13b, palm-8b, palm-30b (B2.6)

### DIFF
--- a/ONNXim/.gitignore
+++ b/ONNXim/.gitignore
@@ -1,3 +1,6 @@
 models/*
+!models/language_models/
+models/language_models/*
+!models/language_models/*.json
 model_lists/*
 build/*

--- a/ONNXim/models/language_models/llama2-13b.json
+++ b/ONNXim/models/language_models/llama2-13b.json
@@ -1,0 +1,15 @@
+{
+  "num_hidden_layers": 40,
+  "hidden_size": 5120,
+  "num_kv_heads": 40,
+  "num_attention_heads": 40,
+  "intermediate_size": 13824,
+  "ffn_type": "llama",
+  "activation_function": "swish",
+  "vocab_size": 32000,
+  "max_seq_length": 4096,
+  "run_single_layer": true,
+  "tensor_parallel_size": 1,
+  "pipeline_parallel_size": 1,
+  "source_note": "Meta LLaMA-2 13B (Touvron et al., 2023). MHA (no GQA at 13B scale). Used as the target (TLM) of the Medium model pair in AHASPro.md Table 1."
+}

--- a/ONNXim/models/language_models/opt-6.7b.json
+++ b/ONNXim/models/language_models/opt-6.7b.json
@@ -1,0 +1,15 @@
+{
+  "num_hidden_layers": 32,
+  "hidden_size": 4096,
+  "num_kv_heads": 32,
+  "num_attention_heads": 32,
+  "intermediate_size": 16384,
+  "ffn_type": "opt",
+  "activation_function": "relu",
+  "vocab_size": 50272,
+  "max_seq_length": 2048,
+  "run_single_layer": true,
+  "tensor_parallel_size": 1,
+  "pipeline_parallel_size": 1,
+  "source_note": "Meta OPT-6.7B (Zhang et al., 2022). Used as the target (TLM) of the Small model pair in AHASPro.md Table 1."
+}

--- a/ONNXim/models/language_models/palm-30b.json
+++ b/ONNXim/models/language_models/palm-30b.json
@@ -1,0 +1,15 @@
+{
+  "num_hidden_layers": 40,
+  "hidden_size": 8192,
+  "num_kv_heads": 1,
+  "num_attention_heads": 32,
+  "intermediate_size": 32768,
+  "ffn_type": "llama",
+  "activation_function": "swish",
+  "vocab_size": 256000,
+  "max_seq_length": 2048,
+  "run_single_layer": true,
+  "tensor_parallel_size": 1,
+  "pipeline_parallel_size": 1,
+  "source_note": "PaLM-like 30B target model used in AHASPro.md Table 1 (hidden 8192). No official 30B checkpoint in the PaLM paper; shape interpolated between PaLM 8B and 62B while preserving the PaLM architecture (SwiGLU FFN, multi-query attention, d_head=256 scaling). ffn_type 'llama' reuses the closest SwiGLU path in the ONNXim language-model loader."
+}

--- a/ONNXim/models/language_models/palm-8b.json
+++ b/ONNXim/models/language_models/palm-8b.json
@@ -1,0 +1,15 @@
+{
+  "num_hidden_layers": 32,
+  "hidden_size": 4096,
+  "num_kv_heads": 1,
+  "num_attention_heads": 16,
+  "intermediate_size": 16384,
+  "ffn_type": "llama",
+  "activation_function": "swish",
+  "vocab_size": 256000,
+  "max_seq_length": 2048,
+  "run_single_layer": true,
+  "tensor_parallel_size": 1,
+  "pipeline_parallel_size": 1,
+  "source_note": "PaLM-like 8B draft model used in AHASPro.md Table 1 (hidden 4096). PaLM architecture (Chowdhery et al., 2022): SwiGLU FFN and multi-query attention (num_kv_heads=1); ffn_type 'llama' reuses the closest SwiGLU path in the ONNXim language-model loader. PaLM-scale SentencePiece vocabulary ~256K."
+}


### PR DESCRIPTION
Closes #3.

## Summary

Table 1 of `AHASPro.md` specifies three Small/Medium/Large draft+target
model pairs, but four of the six JSONs were missing from
`ONNXim/models/language_models/`. This PR ships them so Path B end-to-end
smoke runs (B2.7) and §5.2 ablation / §5.3 SOTA sweeps can actually
resolve all referenced model names.

## Changes

- `opt-6.7b.json` — Meta OPT-6.7B, TLM of the Small pair.
- `llama2-13b.json` — Meta LLaMA-2 13B (MHA, no GQA at 13B), TLM of Medium.
- `palm-8b.json` — PaLM-like 8B draft (hidden 4096), MQA, SwiGLU.
- `palm-30b.json` — PaLM-like 30B target (hidden 8192 per paper), MQA, SwiGLU.
- `ONNXim/.gitignore` — relax the `models/*` blanket rule to whitelist
  `models/language_models/*.json`. Bulk weight files under `models/` stay
  ignored.

All four JSONs match the existing schema used by `opt-1.3b.json`, pass
`python -m json.tool` validation, and carry `source_note` fields tying
each config back to the paper table or the corresponding public
architecture spec.

## Test plan

- [x] `python3 -c "import json; json.load(open(...))"` succeeds for all four files.
- [x] `git check-ignore` confirms the new whitelist rule actually un-ignores
      the four files.
- [ ] Full smoke run against the new configs is part of B2.7 (follow-up).

## Notes

- The existing 5 reference JSONs (`opt-1.3b.json`, `opt-125m.json`,
  `opt-66b.json`, `llama2-7b.json`, `llama3-8b.json`) were already present
  in the working tree as untracked files (copied from the reference repo)
  and remain so after this PR — they are out of scope here.
- PaLM-Like-30B has no official checkpoint; the architecture follows the
  PaLM paper while keeping `hidden_size = 8192` as required by the paper's
  Table 1. Documented in the file's `source_note`.

Made with [Cursor](https://cursor.com)