### PR TITLE
[feat]: synthetic acceptance model + trace generation (B2.5)

### DIFF
--- a/ONNXim/src/Common.cc
+++ b/ONNXim/src/Common.cc
@@ -186,6 +186,24 @@ SimulationConfig initialize_config(json config) {
   if (config.contains("energy_gtsu_switch_pj_per_event"))
     parsed_config.energy_gtsu_switch_pj_per_event = config["energy_gtsu_switch_pj_per_event"];
 
+  /* B2.5 — synthetic acceptance model. All optional; defaults in
+   * SimulationConfig.h match the paper-era SpecDec 0.85 base acceptance.
+   */
+  if (config.contains("accept_mode"))
+    parsed_config.accept_mode = config["accept_mode"].get<std::string>();
+  if (config.contains("accept_base"))
+    parsed_config.accept_base = config["accept_base"];
+  if (config.contains("accept_entropy_alpha"))
+    parsed_config.accept_entropy_alpha = config["accept_entropy_alpha"];
+  if (config.contains("accept_length_decay"))
+    parsed_config.accept_length_decay = config["accept_length_decay"];
+  if (config.contains("accept_p_min"))
+    parsed_config.accept_p_min = config["accept_p_min"];
+  if (config.contains("accept_rng_seed"))
+    parsed_config.accept_rng_seed = config["accept_rng_seed"].get<uint64_t>();
+  if (config.contains("accept_trace_path"))
+    parsed_config.accept_trace_path = config["accept_trace_path"].get<std::string>();
+
   if (config.contains("partition")) {
     for (int i=0; i<parsed_config.num_cores; i++) {
       std::string core_partition = "core_" + std::to_string(i);

--- a/ONNXim/src/SimulationConfig.h
+++ b/ONNXim/src/SimulationConfig.h
@@ -115,6 +115,22 @@ struct SimulationConfig {
   double energy_bus_pj_per_byte = 40.0;
   double energy_gtsu_switch_pj_per_event = 20000.0;
 
+  /* B2.5 — synthetic acceptance model.
+   *   accept_mode: "parametric" | "trace_replay" | "trace_then_parametric"
+   *   accept_base/alpha/length_decay/p_min: parametric curve coefficients
+   *   accept_rng_seed: determinism knob so different runs with the same
+   *                    seed sample identical accepted_length sequences
+   *   accept_trace_path: optional CSV of (round,draft_length,avg_entropy,
+   *                      accepted_length) rows; unused in pure parametric
+   */
+  std::string accept_mode = "parametric";
+  double accept_base = 0.85;
+  double accept_entropy_alpha = 0.12;
+  double accept_length_decay = 0.30;
+  double accept_p_min = 0.05;
+  uint64_t accept_rng_seed = 0x5A5A5A5A5A5A5A5AULL;
+  std::string accept_trace_path = "";
+
   /*
    * This map stores the partition information: <partition_id, core_id>
    *

--- a/ONNXim/src/Simulator.cc
+++ b/ONNXim/src/Simulator.cc
@@ -341,6 +341,13 @@ void Simulator::cycle() {
   if (_cosim) {
     _cosim->print_statistics(_core_cycles);
   }
+  // B2.5 — synthetic acceptance model summary. Only present in speculative
+  // language mode; silent otherwise so legacy runs don't gain noise.
+  if (_lang_scheduler && _lang_scheduler->is_speculative()) {
+    if (auto* spec = dynamic_cast<SpecDecodeScheduler*>(_lang_scheduler.get())) {
+      spec->print_acceptance_stats();
+    }
+  }
 
   // B2.4 — assemble final energy aggregate and emit `Total Energy` line.
   // Core stats were updated by print_stats() above, so `_stat_tot_*` reflect

--- a/ONNXim/src/SyntheticAcceptanceModel.cc
+++ b/ONNXim/src/SyntheticAcceptanceModel.cc
@@ -1,0 +1,168 @@
+// B2.5 — Synthetic acceptance model implementation.
+//
+// The three modes (parametric / trace_replay / trace_then_parametric) share
+// the parametric sampler; `trace_replay` short-circuits if the CSV row is
+// present. The CSV loader is tolerant to blank lines and `#` comments so
+// the trace generator can embed provenance at the top of the file.
+
+#include "SyntheticAcceptanceModel.h"
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <random>
+#include <sstream>
+#include <string>
+
+namespace ahasd_accept {
+
+namespace {
+
+std::string trim(const std::string& s) {
+  size_t b = s.find_first_not_of(" \t\r\n");
+  if (b == std::string::npos) return "";
+  size_t e = s.find_last_not_of(" \t\r\n");
+  return s.substr(b, e - b + 1);
+}
+
+AcceptanceMode parse_mode(const std::string& s) {
+  if (s == "trace_replay") return AcceptanceMode::TRACE_REPLAY;
+  if (s == "trace_then_parametric") return AcceptanceMode::TRACE_THEN_PARAMETRIC;
+  return AcceptanceMode::PARAMETRIC;
+}
+
+}  // namespace
+
+void SyntheticAcceptanceModel::load_from_config(const SimulationConfig& config) {
+  _coeffs.base         = config.accept_base;
+  _coeffs.alpha        = config.accept_entropy_alpha;
+  _coeffs.length_decay = config.accept_length_decay;
+  _coeffs.p_min        = config.accept_p_min;
+  _seed                = config.accept_rng_seed;
+  _mode                = parse_mode(config.accept_mode);
+  _trace_rows.clear();
+  if (!config.accept_trace_path.empty()) {
+    load_trace_csv(config.accept_trace_path);
+  }
+  spdlog::info("[Acceptance] mode={} base={:.3f} alpha={:.3f} length_decay={:.3f} p_min={:.3f} seed={} trace_rows={}",
+               config.accept_mode, _coeffs.base, _coeffs.alpha,
+               _coeffs.length_decay, _coeffs.p_min, _seed,
+               _trace_rows.size());
+}
+
+void SyntheticAcceptanceModel::load_trace_csv(const std::string& path) {
+  std::ifstream in(path);
+  if (!in) {
+    spdlog::warn("[Acceptance] could not open trace '{}'; falling back to parametric", path);
+    return;
+  }
+  std::string line;
+  size_t lineno = 0;
+  bool header_seen = false;
+  // We expect the generator to emit rows with an implicit (request_id=0,
+  // spec_round=row_index). Later enhancements can embed request_id. For
+  // B2.5 the smoke has a single request so this suffices.
+  uint32_t default_request_id = 0;
+  uint32_t implicit_round = 0;
+  while (std::getline(in, line)) {
+    ++lineno;
+    std::string t = trim(line);
+    if (t.empty() || t[0] == '#') continue;
+    if (!header_seen) {
+      header_seen = true;
+      if (t.find("draft_length") != std::string::npos) continue;
+    }
+    std::stringstream ss(t);
+    std::string cell;
+    std::vector<std::string> cells;
+    while (std::getline(ss, cell, ',')) cells.push_back(trim(cell));
+    // Accept either 4 (round,draft_length,avg_entropy,accepted_length) or
+    // 5 (request_id,round,draft_length,avg_entropy,accepted_length) columns.
+    TraceKey key{default_request_id, implicit_round};
+    TraceRow row;
+    try {
+      if (cells.size() == 4) {
+        key.spec_round = static_cast<uint32_t>(std::stoul(cells[0]));
+        row.draft_length = static_cast<uint32_t>(std::stoul(cells[1]));
+        row.avg_entropy = std::stof(cells[2]);
+        row.accepted_length = static_cast<uint32_t>(std::stoul(cells[3]));
+      } else if (cells.size() == 5) {
+        key.request_id = static_cast<uint32_t>(std::stoul(cells[0]));
+        key.spec_round = static_cast<uint32_t>(std::stoul(cells[1]));
+        row.draft_length = static_cast<uint32_t>(std::stoul(cells[2]));
+        row.avg_entropy = std::stof(cells[3]);
+        row.accepted_length = static_cast<uint32_t>(std::stoul(cells[4]));
+      } else {
+        spdlog::warn("[Acceptance] skipping trace line {} (expected 4 or 5 columns, got {})",
+                     lineno, cells.size());
+        continue;
+      }
+    } catch (const std::exception& e) {
+      spdlog::warn("[Acceptance] skipping malformed trace line {}: {}", lineno, e.what());
+      continue;
+    }
+    _trace_rows[key] = row;
+    ++implicit_round;
+  }
+  spdlog::info("[Acceptance] loaded {} rows from '{}'", _trace_rows.size(), path);
+}
+
+std::optional<TraceRow> SyntheticAcceptanceModel::lookup_trace(uint32_t request_id,
+                                                                uint32_t spec_round) const {
+  auto it = _trace_rows.find(TraceKey{request_id, spec_round});
+  if (it == _trace_rows.end()) return std::nullopt;
+  return it->second;
+}
+
+uint32_t SyntheticAcceptanceModel::sample_parametric(uint32_t request_id,
+                                                      uint32_t spec_round,
+                                                      uint32_t draft_length,
+                                                      float entropy_hint) {
+  if (draft_length == 0) return 0;
+  // Per-(request, round) RNG seed: XORing the three inputs plus the global
+  // seed gives us reproducibility without cross-request correlation.
+  uint64_t rng_seed = _seed
+                       ^ (static_cast<uint64_t>(request_id) * 0x9E3779B97F4A7C15ULL)
+                       ^ (static_cast<uint64_t>(spec_round) * 0xBF58476D1CE4E5B9ULL);
+  std::mt19937_64 rng(rng_seed);
+  std::uniform_real_distribution<double> u01(0.0, 1.0);
+  double base = std::max(_coeffs.p_min,
+                         std::min(1.0, _coeffs.base * std::exp(-_coeffs.alpha * entropy_hint)));
+  uint32_t accepted = 0;
+  const double denom = std::max<double>(1.0, static_cast<double>(draft_length - 1));
+  for (uint32_t i = 0; i < draft_length; ++i) {
+    double frac = static_cast<double>(i) / denom;
+    double p = base * (1.0 - _coeffs.length_decay * frac);
+    if (p < _coeffs.p_min) p = _coeffs.p_min;
+    if (p > 1.0) p = 1.0;
+    if (u01(rng) <= p) {
+      ++accepted;
+    } else {
+      break;  // first rejection terminates the chain
+    }
+  }
+  return accepted;
+}
+
+uint32_t SyntheticAcceptanceModel::sample(uint32_t request_id,
+                                           uint32_t spec_round,
+                                           uint32_t draft_length,
+                                           float entropy_hint) {
+  if (_mode == AcceptanceMode::TRACE_REPLAY ||
+      _mode == AcceptanceMode::TRACE_THEN_PARAMETRIC) {
+    if (auto row = lookup_trace(request_id, spec_round)) {
+      // Honour the trace's recorded acceptance. If the draft length the
+      // scheduler picked differs from what the trace row said, clamp.
+      return std::min<uint32_t>(row->accepted_length, draft_length);
+    }
+    if (_mode == AcceptanceMode::TRACE_THEN_PARAMETRIC) {
+      spdlog::debug("[Acceptance] fallback parametric for request={} round={} (no trace row)",
+                    request_id, spec_round);
+    }
+  }
+  return sample_parametric(request_id, spec_round, draft_length, entropy_hint);
+}
+
+}  // namespace ahasd_accept

--- a/ONNXim/src/SyntheticAcceptanceModel.h
+++ b/ONNXim/src/SyntheticAcceptanceModel.h
@@ -1,0 +1,95 @@
+#pragma once
+// B2.5 — Synthetic acceptance model for speculative decoding.
+//
+// Replaces the `accepted_length = ceil(k/2)` placeholder that B2.1 left in
+// SpecDecodeScheduler. Acceptance now depends on both the EDC-selected
+// draft length `k` AND the per-round entropy hint that SpecDecodeScheduler
+// already computes.
+//
+// Two modes:
+//   - parametric        : p_accept(i | k, H) = base * exp(-alpha*H)
+//                         * (1 - length_decay * i / max(1, k-1)),
+//                         clamped to [p_min, 1.0]; first rejection
+//                         terminates the chain (standard spec-decode
+//                         semantics).
+//   - trace_replay      : read a CSV with header
+//                         `round,draft_length,avg_entropy,accepted_length`;
+//                         lookup by (request_id, spec_round) falls back
+//                         to parametric if the row is absent.
+//   - trace_then_parametric : same as trace_replay but logs an `[Acceptance]
+//                         fallback` line when falling through.
+//
+// Determinism: each (request_id, spec_round) pair seeds an independent
+// `std::mt19937_64`. Re-running with the same `accept_rng_seed` yields
+// identical accepted_length sequences, which is what B2.7's "AHASD on vs
+// off produces different `total_cycles`" smoke needs to compare against a
+// stable baseline.
+
+#include "SimulationConfig.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace ahasd_accept {
+
+struct AcceptanceCoeffs {
+  double base         = 0.85;
+  double alpha        = 0.12;   // entropy scale
+  double length_decay = 0.30;   // p at i=k-1 vs p at i=0
+  double p_min        = 0.05;
+};
+
+enum class AcceptanceMode {
+  PARAMETRIC,
+  TRACE_REPLAY,
+  TRACE_THEN_PARAMETRIC,
+};
+
+struct TraceKey {
+  uint32_t request_id;
+  uint32_t spec_round;
+  bool operator==(const TraceKey& other) const {
+    return request_id == other.request_id && spec_round == other.spec_round;
+  }
+};
+struct TraceKeyHash {
+  size_t operator()(const TraceKey& k) const noexcept {
+    return (static_cast<size_t>(k.request_id) << 32) ^ k.spec_round;
+  }
+};
+
+struct TraceRow {
+  uint32_t draft_length   = 0;
+  float    avg_entropy    = 0.0f;
+  uint32_t accepted_length = 0;
+};
+
+class SyntheticAcceptanceModel {
+ public:
+  SyntheticAcceptanceModel() = default;
+  void load_from_config(const SimulationConfig& config);
+
+  // Returns the number of accepted tokens in [0, draft_length].
+  uint32_t sample(uint32_t request_id, uint32_t spec_round,
+                  uint32_t draft_length, float entropy_hint);
+
+  AcceptanceMode mode() const { return _mode; }
+  const AcceptanceCoeffs& coeffs() const { return _coeffs; }
+  size_t trace_rows_loaded() const { return _trace_rows.size(); }
+
+ private:
+  uint32_t sample_parametric(uint32_t request_id, uint32_t spec_round,
+                             uint32_t draft_length, float entropy_hint);
+  std::optional<TraceRow> lookup_trace(uint32_t request_id,
+                                       uint32_t spec_round) const;
+  void load_trace_csv(const std::string& path);
+
+  AcceptanceCoeffs _coeffs;
+  AcceptanceMode   _mode = AcceptanceMode::PARAMETRIC;
+  uint64_t         _seed = 0x5A5A5A5A5A5A5A5AULL;
+  std::unordered_map<TraceKey, TraceRow, TraceKeyHash> _trace_rows;
+};
+
+}  // namespace ahasd_accept

--- a/ONNXim/src/scheduler/SpecDecodeScheduler.cc
+++ b/ONNXim/src/scheduler/SpecDecodeScheduler.cc
@@ -39,6 +39,10 @@ SpecDecodeScheduler::SpecDecodeScheduler(std::string name, std::string path,
   }
   spdlog::info("[SpecDecode] max_draft_length={} default_draft_length={}",
                _max_draft_length, _default_draft_length);
+  // B2.5 — bring up the synthetic acceptance model with whatever coeffs
+  // live in SimulationConfig. Parametric by default; trace-replay and
+  // trace_then_parametric kick in once `accept_trace_path` is set.
+  _accept_model.load_from_config(_config);
 }
 
 bool SpecDecodeScheduler::attach_target_model(std::unique_ptr<LanguageModel> target_model,
@@ -101,11 +105,42 @@ uint32_t SpecDecodeScheduler::pick_draft_length(const LangRequest& req) {
 
 uint32_t SpecDecodeScheduler::sample_accepted_length(const LangRequest& req,
                                                      uint32_t draft_length) {
-  // B2.5 will replace this with a trace-driven or synthetic sampler.
-  // Placeholder: accept half of the draft tokens (rounded up), capped by target.
-  (void)req;
+  // B2.5 — SyntheticAcceptanceModel now drives acceptance. We pass the
+  // scheduler's entropy hint (same one EDC saw when it picked k) so the
+  // parametric sampler and EDC are consistent: higher entropy ⇒ lower
+  // base acceptance probability ⇒ fewer accepted tokens, exactly the
+  // dynamic that makes EDC on/off differentiate `total_cycles`.
   if (draft_length == 0) return 0;
-  return std::max<uint32_t>(1u, (draft_length + 1u) / 2u);
+  const float entropy_hint = compute_entropy_hint(req);
+  const uint32_t accepted = _accept_model.sample(req.request_id, req.spec_round,
+                                                  draft_length, entropy_hint);
+  _accept_samples += 1;
+  _accept_sum     += accepted;
+  _accept_k_sum   += draft_length;
+  return accepted;
+}
+
+void SpecDecodeScheduler::print_acceptance_stats() const {
+  const char* mode = "parametric";
+  switch (_accept_model.mode()) {
+    case ahasd_accept::AcceptanceMode::TRACE_REPLAY: mode = "trace_replay"; break;
+    case ahasd_accept::AcceptanceMode::TRACE_THEN_PARAMETRIC: mode = "trace_then_parametric"; break;
+    default: break;
+  }
+  const double mean_accept =
+      _accept_samples > 0 ? static_cast<double>(_accept_sum) / _accept_samples : 0.0;
+  const double mean_k =
+      _accept_samples > 0 ? static_cast<double>(_accept_k_sum) / _accept_samples : 0.0;
+  const double accept_ratio =
+      _accept_k_sum > 0 ? static_cast<double>(_accept_sum) / _accept_k_sum : 0.0;
+  spdlog::info("=== Synthetic Acceptance Stats (B2.5) ===");
+  spdlog::info("Acceptance Mode: {} (trace_rows={})", mode,
+               _accept_model.trace_rows_loaded());
+  spdlog::info("Acceptance Samples: {} | mean_k={:.3f} | mean_accepted={:.3f} | accept_ratio={:.4f}",
+               _accept_samples, mean_k, mean_accept, accept_ratio);
+  const auto& c = _accept_model.coeffs();
+  spdlog::info("Acceptance Coeffs: base={:.3f} alpha={:.3f} length_decay={:.3f} p_min={:.3f}",
+               c.base, c.alpha, c.length_decay, c.p_min);
 }
 
 bool SpecDecodeScheduler::busy() {
@@ -345,6 +380,10 @@ void SpecDecodeScheduler::finish_model(uint32_t model_id) {
   event.model_role = meta.role;
   event.draft_length = meta.draft_length_at_issue;
   event.spec_round = meta.verify_round;
+  // B2.5 — emit the entropy hint the scheduler used for this request so
+  // downstream consumers (log parsers, trace generators that feed back)
+  // see the same value the acceptance model saw.
+  event.avg_entropy = compute_entropy_hint(req);
 
   switch (meta.task_type) {
     case LangTaskType::PROMPT: {

--- a/ONNXim/src/scheduler/SpecDecodeScheduler.h
+++ b/ONNXim/src/scheduler/SpecDecodeScheduler.h
@@ -16,6 +16,7 @@
 // milestones can override them without touching this skeleton.
 
 #include "LanguageScheduler.h"
+#include "../SyntheticAcceptanceModel.h"
 
 // B2.3: forward declarations so we do not leak AHASD / PIM headers via the
 // scheduler interface (Simulator.cc injects them via attach_ahasd()).
@@ -44,6 +45,10 @@ class SpecDecodeScheduler : public LangScheduler {
   void finish_model(uint32_t model_id) override;
   bool busy() override;
   uint64_t get_kv_memory_size() override;
+
+  // B2.5 — end-of-simulation summary of synthetic acceptance outcomes.
+  // Simulator calls this once run completes.
+  void print_acceptance_stats() const;
 
  protected:
   // Hooks for later milestones.
@@ -87,6 +92,18 @@ class SpecDecodeScheduler : public LangScheduler {
   // Synthetic entropy hint for EDC (B2.3). Real entropy arrives once the
   // synthetic acceptance model lands in B2.5.
   float compute_entropy_hint(const LangRequest& req) const;
+
+  // B2.5 — synthetic acceptance model. Owned by the scheduler so mode /
+  // coeffs are scoped to the speculative path; load_from_config is called
+  // once in the constructor.
+  ahasd_accept::SyntheticAcceptanceModel _accept_model;
+
+  // B2.5 — smoke + B2.7 consumption: tally of how many rounds the EDC
+  // picked each (k, accepted_length) pair so the end-of-simulation log
+  // can show acceptance distribution without rereading the event stream.
+  uint64_t _accept_samples = 0;
+  uint64_t _accept_sum     = 0;
+  uint64_t _accept_k_sum   = 0;
 
   // Step the state machine for one request; returns true if a model was issued.
   bool try_issue_one_task(LangRequest& req);

--- a/scripts/gen_acceptance_trace.py
+++ b/scripts/gen_acceptance_trace.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+B2.5 — Synthetic acceptance trace generator.
+
+Emits a CSV that the C++ SyntheticAcceptanceModel can replay via
+`accept_trace_path` when `accept_mode` is `trace_replay` or
+`trace_then_parametric`.
+
+Schema (header row is emitted):
+    round,draft_length,avg_entropy,accepted_length
+
+Honesty: this script does NOT run a real LLM. Acceptance rates are drawn
+from per-algorithm literature priors (see ALGO_PRIORS below) and modulated
+by a synthetic entropy schedule that mirrors the scheduler's
+`compute_entropy_hint`. Re-calibration against real LLM draft/target
+outputs belongs to a later milestone — at that point the schema stays
+the same, only the sampling strategy changes.
+
+Usage example:
+    scripts/gen_acceptance_trace.py \
+        --model-pair opt-125m-opt-125m-t \
+        --algorithm specdec \
+        --rounds 32 \
+        --max-draft-length 4 \
+        --seed 2025 \
+        --output /tmp/accept.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import random
+import sys
+from pathlib import Path
+
+# Per-algorithm priors — tuple of (base_acceptance, entropy_alpha,
+# length_decay, p_min). Numbers are a rough synthesis of what the
+# speculative-decoding literature reports for the paper's model pairs:
+#   specdec     : classical speculative sampling (Leviathan et al., 2023)
+#   svip        : stochastic verifier-in-place (SVIP, ASPLOS 2024-class)
+#   adaedl      : adaptive entropy-driven draft length (AdaEDL variants)
+#   banditspec  : bandit-based draft length (ICLR 2024-class)
+# These are NOT calibrated from the paper experiments — B2.7 will exercise
+# the on/off switch; calibration lives in later phases.
+ALGO_PRIORS = {
+    "specdec":    (0.82, 0.10, 0.30, 0.05),
+    "svip":       (0.85, 0.12, 0.25, 0.07),
+    "adaedl":     (0.83, 0.14, 0.20, 0.05),
+    "banditspec": (0.80, 0.09, 0.35, 0.05),
+}
+
+# Per model-family modifiers (lower-cap only; synthesis). Used to bias
+# the base acceptance slightly based on the draft/target model pair so
+# the resulting CSV is reproducible, not just a constant distribution.
+FAMILY_BUMPS = {
+    ("opt", "opt"):     -0.02,
+    ("llama2", "llama2"): 0.00,
+    ("palm", "palm"):   -0.01,
+    ("opt125m", "opt125mt"): -0.03,
+}
+
+
+def family_key(model_name: str) -> str:
+    n = model_name.lower()
+    for fam in ("llama2", "llama3", "palm", "opt"):
+        if n.startswith(fam):
+            return fam
+    return n
+
+
+def parse_model_pair(s: str) -> tuple[str, str]:
+    """
+    Accept formats:
+        <draft>-<target>       e.g. opt-125m-opt-125m-t
+        <draft>:<target>       explicit separator
+    Falls back to splitting at the last '-' pair if ambiguous.
+    """
+    if ":" in s:
+        a, b = s.split(":", 1)
+        return a, b
+    # Best-effort split for hyphenated names: grab the shortest prefix
+    # that matches a known family and use the rest as the target.
+    known_prefixes = ("opt-", "llama2-", "llama3-", "palm-")
+    for pfx in known_prefixes:
+        if s.startswith(pfx):
+            # find the second occurrence of a known prefix
+            for other in known_prefixes:
+                idx = s.find(other, len(pfx))
+                if idx > 0:
+                    return s[:idx].rstrip("-"), s[idx:]
+    # Fall back to midpoint split
+    mid = len(s) // 2
+    return s[:mid].rstrip("-"), s[mid:].lstrip("-")
+
+
+def synthetic_entropy(round_idx: int, total_rounds: int, rng: random.Random) -> float:
+    """Mirror the scheduler's compute_entropy_hint: ramps from 2.5 -> 5.0
+    with a small per-round jitter. Output domain [0.5, 9.5]."""
+    if total_rounds <= 1:
+        ratio = 0.0
+    else:
+        ratio = round_idx / (total_rounds - 1)
+    base = 2.5 + 2.5 * ratio
+    jitter = rng.uniform(-0.25, 0.25) + 0.5 * (round_idx % 4)
+    return max(0.5, min(9.5, base + jitter))
+
+
+def sample_accepted(draft_length: int, entropy: float, coeffs, rng: random.Random) -> int:
+    base, alpha, length_decay, p_min = coeffs
+    if draft_length <= 0:
+        return 0
+    p0 = max(p_min, min(1.0, base * math.exp(-alpha * entropy)))
+    denom = max(1, draft_length - 1)
+    accepted = 0
+    for i in range(draft_length):
+        frac = i / denom
+        p = p0 * (1.0 - length_decay * frac)
+        if p < p_min:
+            p = p_min
+        if p > 1.0:
+            p = 1.0
+        if rng.random() <= p:
+            accepted += 1
+        else:
+            break
+    return accepted
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    ap.add_argument("--model-pair", required=True,
+                    help="draft-target (e.g. opt-125m-opt-125m-t or llama2-7b-llama2-13b)")
+    ap.add_argument("--algorithm", default="specdec", choices=sorted(ALGO_PRIORS.keys()))
+    ap.add_argument("--rounds", type=int, default=32)
+    ap.add_argument("--max-draft-length", type=int, default=4)
+    ap.add_argument("--min-draft-length", type=int, default=1)
+    ap.add_argument("--seed", type=int, default=2025)
+    ap.add_argument("--output", required=True, help="Path for the CSV trace")
+    ap.add_argument("--request-id", type=int, default=None,
+                    help="If set, emit 5-column rows with this request_id prefix")
+    ap.add_argument("--provenance", action="store_true",
+                    help="Emit '# ...' provenance comment lines at the top of the CSV")
+    args = ap.parse_args()
+
+    base, alpha, length_decay, p_min = ALGO_PRIORS[args.algorithm]
+    draft_name, target_name = parse_model_pair(args.model_pair)
+    bump_key = (family_key(draft_name), family_key(target_name))
+    base += FAMILY_BUMPS.get(bump_key, 0.0)
+    coeffs = (base, alpha, length_decay, p_min)
+
+    rng = random.Random(args.seed)
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with out_path.open("w", newline="") as f:
+        if args.provenance:
+            f.write("# B2.5 synthetic acceptance trace (NOT calibrated against real LLMs)\n")
+            f.write(f"# model_pair={args.model_pair} algorithm={args.algorithm}\n")
+            f.write(f"# coeffs base={coeffs[0]:.3f} alpha={coeffs[1]:.3f} "
+                    f"length_decay={coeffs[2]:.3f} p_min={coeffs[3]:.3f}\n")
+            f.write(f"# seed={args.seed} rounds={args.rounds} "
+                    f"max_draft_length={args.max_draft_length}\n")
+        writer = csv.writer(f)
+        if args.request_id is None:
+            writer.writerow(["round", "draft_length", "avg_entropy", "accepted_length"])
+        else:
+            writer.writerow(["request_id", "round", "draft_length",
+                             "avg_entropy", "accepted_length"])
+        for r in range(args.rounds):
+            k = rng.randint(max(1, args.min_draft_length), max(1, args.max_draft_length))
+            h = synthetic_entropy(r, args.rounds, rng)
+            a = sample_accepted(k, h, coeffs, rng)
+            if args.request_id is None:
+                writer.writerow([r, k, f"{h:.4f}", a])
+            else:
+                writer.writerow([args.request_id, r, k, f"{h:.4f}", a])
+
+    print(f"Wrote {args.rounds} rows to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_contract_eval.py
+++ b/scripts/run_contract_eval.py
@@ -62,6 +62,13 @@ METRIC_KEYS = [
     "attention_class_tagged_bytes",
     "attention_class_tagged_read_bytes",
     "attention_class_tagged_write_bytes",
+    # B2.5 — synthetic acceptance model stats.
+    "acceptance_mode",
+    "acceptance_trace_rows",
+    "acceptance_samples",
+    "acceptance_mean_k",
+    "acceptance_mean_accepted",
+    "acceptance_ratio",
 ]
 
 

--- a/scripts/run_single_config.py
+++ b/scripts/run_single_config.py
@@ -690,6 +690,19 @@ def parse_simulation_log(log_file, config):
             
             if match := re.search(r'Average Draft Entropy:\s*([\d.]+)', content):
                 results['metrics']['average_entropy'] = float(match.group(1))
+
+            # B2.5 — synthetic acceptance model stats (best-effort parse;
+            # absent on legacy/non-speculative runs ⇒ keys simply skipped).
+            if match := re.search(r'Acceptance Mode:\s*([A-Za-z_]+)\s*\(trace_rows=(\d+)\)', content):
+                results['metrics']['acceptance_mode'] = match.group(1)
+                results['metrics']['acceptance_trace_rows'] = int(match.group(2))
+            if match := re.search(
+                    r'Acceptance Samples:\s*(\d+)\s*\|\s*mean_k=([\d.]+)\s*\|\s*mean_accepted=([\d.]+)\s*\|\s*accept_ratio=([\d.]+)',
+                    content):
+                results['metrics']['acceptance_samples'] = int(match.group(1))
+                results['metrics']['acceptance_mean_k'] = float(match.group(2))
+                results['metrics']['acceptance_mean_accepted'] = float(match.group(3))
+                results['metrics']['acceptance_ratio'] = float(match.group(4))
             
             # Parse EDC statistics if enabled
             if config['ahasd']['enable_edc'] and 'EDC Statistics' in content:


### PR DESCRIPTION
## Summary
- New `SyntheticAcceptanceModel` replaces SpecDecodeScheduler's `ceil(k/2)` placeholder; acceptance is now driven by `(draft_length, entropy_hint)` with first-rejection chain semantics.
- Three modes: `parametric`, `trace_replay`, `trace_then_parametric`, selected via `accept_mode` + `accept_trace_path` in SimulationConfig.
- New script `scripts/gen_acceptance_trace.py` produces the canonical CSV the C++ loader replays, with per-algorithm (specdec/svip/adaedl/banditspec) literature priors.
- Log parsing plumbed through `run_single_config.py` (6 new regex hits) and `run_contract_eval.py` (6 new METRIC_KEYS).

## Smoke
Prompt=4, gen=4, draft=opt-125m, target=opt-125m-t, max_k=4:
- Parametric: 10 rounds, mean_k=2.000, mean_accepted=0.400, accept_ratio=0.2000, final_npu_cycle=1740245
- Trace replay (16-row CSV): 2 rounds, mean_k=3.000, mean_accepted=2.000, accept_ratio=0.6667, final_npu_cycle=506084
- Both depart clearly from the B2.4 placeholder (3 rounds / 0.5714).

## Test plan
- [x] `cmake . && cmake --build .` succeeds cleanly
- [x] `gen_acceptance_trace.py --rounds 16 --seed 2025` produces a CSV with non-trivial variance
- [x] Parametric-mode smoke differs from trace-replay smoke
- [x] Python log regexes hit all 6 acceptance fields in both runs

## Out of scope
- Calibration of coefficients against a real LLM (intentionally synthesis-only for now).
- Multi-request trace CSV format (single `request_id=0` assumption for now; 5-column format supported but unused until B2.7).

Closes #9.

Made with [Cursor](https://cursor.com)