### PR TITLE
[fix][feat]: AAU tagging + bypass cycle coupling (issue #15)

### DIFF
--- a/ONNXim/src/CoSimDriver.cc
+++ b/ONNXim/src/CoSimDriver.cc
@@ -10,6 +10,11 @@ uint32_t CoSimDriver::on_dram_push(uint32_t cid, MemoryAccess* req, uint64_t npu
   return _pim->on_dram_push(cid, req, npu_cycle);
 }
 
+bool CoSimDriver::try_aau_bypass(uint32_t cid, MemoryAccess* req, uint64_t npu_cycle) {
+  if (!_pim) return false;
+  return _pim->try_aau_bypass(cid, req, npu_cycle);
+}
+
 void CoSimDriver::on_dram_pop(uint32_t cid, MemoryAccess* req, uint64_t npu_cycle) {
   if (!_pim) return;
   _pim->on_dram_pop(cid, req, npu_cycle);

--- a/ONNXim/src/CoSimDriver.h
+++ b/ONNXim/src/CoSimDriver.h
@@ -29,6 +29,14 @@ class CoSimDriver {
   uint32_t on_dram_push(uint32_t cid, MemoryAccess* req, uint64_t npu_cycle);
   void on_dram_pop(uint32_t cid, MemoryAccess* req, uint64_t npu_cycle);
   void cycle(uint64_t npu_cycle);
+  // AAU bypass: if request qualifies for AAU fusion, this consumes it
+  // (incrementing AAU stats) and Simulator routes it through its bypass
+  // queue with PIMBackend::bypass_latency_npu_cycles() latency instead of
+  // touching DRAM.
+  bool try_aau_bypass(uint32_t cid, MemoryAccess* req, uint64_t npu_cycle);
+  uint64_t bypass_latency_npu_cycles() const {
+    return _pim ? _pim->bypass_latency_npu_cycles() : 0;
+  }
 
   // End-of-simulation summary printer.
   void print_statistics(uint64_t final_npu_cycle) const;

--- a/ONNXim/src/Common.cc
+++ b/ONNXim/src/Common.cc
@@ -165,6 +165,8 @@ SimulationConfig initialize_config(json config) {
     parsed_config.pim_aau_fusion_ratio = config["pim_aau_fusion_ratio"];
   if (config.contains("pim_gtsu_switch_ns"))
     parsed_config.pim_gtsu_switch_ns = config["pim_gtsu_switch_ns"];
+  if (config.contains("pim_aau_bypass_ns"))
+    parsed_config.pim_aau_bypass_ns = config["pim_aau_bypass_ns"];
 
   /* B2.4 — energy model coefficients (LUT, per pJ). All optional. */
   if (config.contains("energy_npu_active_pj_per_cycle"))

--- a/ONNXim/src/PIMBackend.cc
+++ b/ONNXim/src/PIMBackend.cc
@@ -36,6 +36,9 @@ PIMBackend::PIMBackend(SimulationConfig config) : _config(config) {
       static_cast<uint32_t>((static_cast<double>(_config.pim_gtsu_switch_ns) * 1e-9) *
                             (static_cast<double>(_config.core_freq) * 1e6));
   if (_gtsu_switch_npu_cycles == 0) _gtsu_switch_npu_cycles = 1;
+  _aau_bypass_npu_cycles =
+      static_cast<uint32_t>((static_cast<double>(_config.pim_aau_bypass_ns) * 1e-9) *
+                            (static_cast<double>(_config.core_freq) * 1e6));
 
   spdlog::info("[PIMBackend] active: pim_channels={}/{} pim_clock={} MHz npu/pim ratio={:.3f} "
                "gtsu_switch={} ns ({} NPU cycles) aau_fusion={} ratio={:.2f}",
@@ -87,12 +90,10 @@ uint32_t PIMBackend::on_dram_push(uint32_t cid, MemoryAccess* req, uint64_t npu_
     }
     if (req->request_identity_tagged) _stats.total_attention_class_requests++;
   }
-  if (should_apply_aau_fusion(req)) {
-    const uint64_t saved = static_cast<uint64_t>(
-        static_cast<double>(req->size) * static_cast<double>(_config.pim_aau_fusion_ratio));
-    _stats.total_aau_fused_events++;
-    _stats.total_aau_fusion_saved_bytes += saved;
-  }
+  // Note: AAU fusion statistics are now emitted in try_aau_bypass(), which
+  // Simulator calls BEFORE on_dram_push so fused requests never hit DRAM.
+  // Anything reaching on_dram_push is non-fused traffic that still pays
+  // GTSU/TVC holds on PIM channels.
   uint64_t hold_until = _per_channel_hold_until_npu[cid];
   if (hold_until > npu_cycle) {
     uint64_t hold = hold_until - npu_cycle;
@@ -101,6 +102,31 @@ uint32_t PIMBackend::on_dram_push(uint32_t cid, MemoryAccess* req, uint64_t npu_
         hold, std::numeric_limits<uint32_t>::max()));
   }
   return 0;
+}
+
+bool PIMBackend::try_aau_bypass(uint32_t cid, MemoryAccess* req,
+                                uint64_t /*npu_cycle*/) {
+  if (!_active || !is_pim_channel(cid)) return false;
+  if (!should_apply_aau_fusion(req)) return false;
+  if (_aau_bypass_npu_cycles == 0) return false;
+  // AAU absorbs this K/V fetch entirely — the request will complete via
+  // the bypass queue in Simulator with _aau_bypass_npu_cycles of latency.
+  // Since Simulator skips on_dram_push for bypassed requests, ALL stats
+  // normally maintained there must be attributed here for this request.
+  _stats.total_pim_requests++;
+  if (req->write) {
+    _stats.total_pim_write_requests++;
+    _stats.total_pim_write_bytes += req->size;
+  } else {
+    _stats.total_pim_read_requests++;
+    _stats.total_pim_read_bytes += req->size;
+  }
+  _stats.total_attention_class_requests++;
+  const uint64_t saved = static_cast<uint64_t>(
+      static_cast<double>(req->size) * static_cast<double>(_config.pim_aau_fusion_ratio));
+  _stats.total_aau_fused_events++;
+  _stats.total_aau_fusion_saved_bytes += saved;
+  return true;
 }
 
 void PIMBackend::on_dram_pop(uint32_t cid, MemoryAccess* req, uint64_t npu_cycle) {
@@ -180,6 +206,8 @@ void PIMBackend::print_statistics(uint64_t final_npu_cycle) const {
                _stats.total_pim_read_bytes, _stats.total_pim_write_bytes);
   spdlog::info("[PIMBackend] attention-class requests through PIM: {}",
                _stats.total_attention_class_requests);
+  spdlog::info("[PIMBackend] AAU bypass latency (NPU cycles/event): {}",
+               _aau_bypass_npu_cycles);
   spdlog::info("[PIMBackend] AAU fused events: {} ; saved bytes: {}",
                _stats.total_aau_fused_events, _stats.total_aau_fusion_saved_bytes);
   spdlog::info("[PIMBackend] GTSU switches: {} ; total stall cycles: {}",

--- a/ONNXim/src/PIMBackend.h
+++ b/ONNXim/src/PIMBackend.h
@@ -47,6 +47,14 @@ class PIMBackend {
   // TVC are the B2.3 users of this hold-back.
   uint32_t on_dram_push(uint32_t cid, MemoryAccess* req, uint64_t npu_cycle);
 
+  // AAU bypass path (B2.3+): when attention-class traffic can be serviced
+  // directly by PIM-internal AAU (score compute + partial reductions), the
+  // request never hits DRAM. `try_aau_bypass` returns true iff the request
+  // was consumed by AAU — the caller MUST skip DRAM push and route the
+  // request back into the response path after `bypass_latency_npu_cycles`.
+  bool try_aau_bypass(uint32_t cid, MemoryAccess* req, uint64_t npu_cycle);
+  uint64_t bypass_latency_npu_cycles() const { return _aau_bypass_npu_cycles; }
+
   // Called by Simulator when a memory response leaves DRAM → ICNT.
   void on_dram_pop(uint32_t cid, MemoryAccess* req, uint64_t npu_cycle);
 
@@ -104,6 +112,7 @@ class PIMBackend {
   uint32_t _num_pim_channels = 0;
   double _npu_to_pim_ratio = 1.0;  // pim_clock / npu_clock
   uint32_t _gtsu_switch_npu_cycles = 0;
+  uint32_t _aau_bypass_npu_cycles = 0;
 
   Stats _stats;
 };

--- a/ONNXim/src/SimulationConfig.h
+++ b/ONNXim/src/SimulationConfig.h
@@ -100,6 +100,13 @@ struct SimulationConfig {
   bool pim_enable_aau_fusion = true;
   float pim_aau_fusion_ratio = 0.75f;
   uint32_t pim_gtsu_switch_ns = 55;
+  /* pim_aau_bypass_ns:
+   *   AAU's internal service time for a fused K/V request.  Set to 0 to
+   *   disable bypass (fused requests still return their bytes via DRAM,
+   *   AAU stays energy-only).  Default 18 ns models HBM2 PIM-rank tCCDL-like
+   *   one-row-activation plus AAU reduction pipeline.
+   */
+  uint32_t pim_aau_bypass_ns = 18;
 
   /* B2.4 — energy-model coefficients (LUT, per-pJ). Defaults are documented
    * in EnergyModel.h. All keys are optional in onnxim_config.json; absent

--- a/ONNXim/src/Simulator.cc
+++ b/ONNXim/src/Simulator.cc
@@ -79,6 +79,7 @@ Simulator::Simulator(SimulationConfig config, bool language_mode)
   // B2.2 — instantiate PIM co-simulation driver (no-op when pim_enable=false).
   _cosim = std::make_unique<CoSimDriver>(_config);
   _pim_hold_queues.resize(_n_memories);
+  _pim_bypass_queues.resize(_n_memories);
   if (_cosim->is_active()) {
     spdlog::info("[Simulator] PIM co-sim active; per-channel hold queues sized to {}", _n_memories);
   }
@@ -230,21 +231,49 @@ void Simulator::cycle() {
         if (!_icnt->is_empty(_n_cores + mem_id) &&
             !_dram->is_full(mem_id, _icnt->top(_n_cores + mem_id))) {
           MemoryAccess* front = _icnt->top(_n_cores + mem_id);
-          // B2.2 — PIM overlay: may request that this push be held for a few
-          // NPU cycles (GTSU switch, TVC pre-verify window). When active and
-          // a hold is requested, park the request rather than passing to DRAM.
-          uint32_t hold = 0;
+          // B2.2/issue-15 — AAU bypass: attention-class K/V reads on PIM
+          // channels never hit DRAM; AAU serves them with a short bypass
+          // latency and routes the response back through ICNT directly.
+          bool bypassed = false;
           if (_cosim && _cosim->is_active()) {
-            hold = _cosim->on_dram_push(mem_id, front, _core_cycles);
+            bypassed = _cosim->try_aau_bypass(mem_id, front, _core_cycles);
           }
-          if (hold == 0) {
-            _dram->push(mem_id, front);
+          if (bypassed) {
+            // Build fake completion: response mode flips to read-done.
+            front->request = false;
+            _pim_bypass_queues[mem_id].push(
+                {_core_cycles + _cosim->bypass_latency_npu_cycles(), front});
+            _icnt->pop(_n_cores + mem_id);
+            _nr_to_mem++;
+            _tot_nr_to_mem++;
           } else {
-            _pim_hold_queues[mem_id].push({_core_cycles + hold, front});
+            // B2.2 — PIM overlay: may request that this push be held for a
+            // few NPU cycles (GTSU switch, TVC pre-verify window).
+            uint32_t hold = 0;
+            if (_cosim && _cosim->is_active()) {
+              hold = _cosim->on_dram_push(mem_id, front, _core_cycles);
+            }
+            if (hold == 0) {
+              _dram->push(mem_id, front);
+            } else {
+              _pim_hold_queues[mem_id].push({_core_cycles + hold, front});
+            }
+            _icnt->pop(_n_cores + mem_id);
+            _nr_to_mem++;
+            _tot_nr_to_mem++;
           }
-          _icnt->pop(_n_cores + mem_id);
-          _nr_to_mem++;
-          _tot_nr_to_mem++;
+        }
+        // B2.2/issue-15 — drain AAU bypass queue: ready requests go straight
+        // into the ICNT response path (skipping DRAM entirely).
+        if (_cosim && _cosim->is_active() && !_pim_bypass_queues[mem_id].empty()) {
+          auto& bfront = _pim_bypass_queues[mem_id].front();
+          if (bfront.first <= _core_cycles &&
+              !_icnt->is_full(_n_cores + mem_id, bfront.second)) {
+            _icnt->push(_n_cores + mem_id, get_dest_node(bfront.second), bfront.second);
+            _pim_bypass_queues[mem_id].pop();
+            _nr_from_mem++;
+            _tot_nr_from_mem++;
+          }
         }
         // Pop response to ICNT from dram
         if (!_dram->is_empty(mem_id) &&
@@ -464,6 +493,9 @@ bool Simulator::running() {
   // B2.2 — outstanding PIM holds count as running work.
   if (_cosim && _cosim->is_active()) {
     for (const auto& q : _pim_hold_queues) {
+      if (!q.empty()) { running = true; break; }
+    }
+    for (const auto& q : _pim_bypass_queues) {
       if (!q.empty()) { running = true; break; }
     }
   }

--- a/ONNXim/src/Simulator.h
+++ b/ONNXim/src/Simulator.h
@@ -79,6 +79,10 @@ class Simulator {
   // handed to the DRAM backend immediately. Entries are (release_npu_cycle,
   // MemoryAccess*).
   std::vector<std::queue<std::pair<uint64_t, MemoryAccess*>>> _pim_hold_queues;
+  // AAU bypass queue: (ready_cycle, req). Requests placed here by AAU
+  // never hit DRAM; Simulator routes them directly into the ICNT response
+  // path once ready_cycle <= _core_cycles.
+  std::vector<std::queue<std::pair<uint64_t, MemoryAccess*>>> _pim_bypass_queues;
 
   // Icnt stat
   uint64_t _nr_from_core=0;

--- a/ONNXim/src/operations/Attention.cc
+++ b/ONNXim/src/operations/Attention.cc
@@ -248,12 +248,14 @@ void Attention::initialize_instructions(Tile* tile, int head_idx, int num_heads)
         key_addrs.push_back(key_addr + *itr);
         value_addrs.push_back(value_addr + *itr);
     }
+    // Tag KV traffic as attention-class so PIMBackend/AAU can fuse it.
     tile->instructions.push_back(std::make_unique<Instruction>(Instruction{
         .opcode = Opcode::MOVIN,
         .dest_addr = sram_k_ofs,
         .size = (uint32_t)value_addrs.size(),
         .src_addrs = key_addrs,
         .operand_id = _INPUT_OPERAND + 1,  // key
+        .request_identity_tagged = true
     }));
     tile->instructions.push_back(std::make_unique<Instruction>(Instruction{
         .opcode = Opcode::MOVIN,
@@ -261,6 +263,7 @@ void Attention::initialize_instructions(Tile* tile, int head_idx, int num_heads)
         .size = (uint32_t)value_addrs.size(),
         .src_addrs = value_addrs,
         .operand_id = _INPUT_OPERAND + 2,  // value
+        .request_identity_tagged = true
     }));
     for (int h_ofs = 0; h_ofs < num_heads; h_ofs++) {
         int h_idx = head_idx + h_ofs;
@@ -380,6 +383,7 @@ void Attention::initialize_instructions(Tile* tile, Mapping mapping, int head_id
         .size = (uint32_t)value_addrs.size(),
         .src_addrs = key_addrs,
         .operand_id = _INPUT_OPERAND + 1,  // key
+        .request_identity_tagged = true
     }));
 
     for (int h_ofs = 0; h_ofs < num_heads; h_ofs++) {
@@ -413,6 +417,7 @@ void Attention::initialize_instructions(Tile* tile, Mapping mapping, int head_id
         .size = (uint32_t)value_addrs.size(),
         .src_addrs = value_addrs,
         .operand_id = _INPUT_OPERAND + 2,  // value
+        .request_identity_tagged = true
     }));
      // -- compute -- //     
     // GEMM (q*k -> l)

--- a/configs/baselines/ahasd_noaau.json
+++ b/configs/baselines/ahasd_noaau.json
@@ -1,0 +1,16 @@
+{
+  "_doc": "AHASD minus AAU — full AHASD software stack (EDC/TVC/GTSU) on PIM-augmented HBM2, but AAU fusion disabled so attention-class traffic still round-trips through DRAM. Isolates AAU's contribution from EDC/TVC/GTSU. Matches B2.7's A_ahasd_noaau axis.",
+  "_inherits": "_base_systolic_c4_128x128_hbm2.json",
+  "enable_ahasd": true,
+  "enable_edc": true,
+  "enable_tvc": true,
+  "enable_aau": false,
+  "max_draft_length": 4,
+  "pim_enable": true,
+  "pim_channel_mask": "",
+  "pim_channel_stride": 2,
+  "pim_clock_mhz": 800,
+  "pim_enable_aau_fusion": false,
+  "pim_aau_fusion_ratio": 0.0,
+  "pim_gtsu_switch_ns": 55
+}

--- a/configs/baselines/pim_only.json
+++ b/configs/baselines/pim_only.json
@@ -1,0 +1,16 @@
+{
+  "_doc": "PIM-only baseline — HBM2 + PIM co-sim channels + AAU fusion, but no AHASD control (EDC/TVC disabled, GTSU runs with default static policy). Isolates the AAU/PIM hardware contribution from the AHASD software stack. Matches B2.7's A_pim_only axis.",
+  "_inherits": "_base_systolic_c4_128x128_hbm2.json",
+  "enable_ahasd": false,
+  "enable_edc": false,
+  "enable_tvc": false,
+  "enable_aau": false,
+  "max_draft_length": 4,
+  "pim_enable": true,
+  "pim_channel_mask": "",
+  "pim_channel_stride": 2,
+  "pim_clock_mhz": 800,
+  "pim_enable_aau_fusion": true,
+  "pim_aau_fusion_ratio": 0.75,
+  "pim_gtsu_switch_ns": 55
+}

--- a/workflow/PROGRESS.md
+++ b/workflow/PROGRESS.md
@@ -1,0 +1,416 @@
+# AHASD → TPDS 修改进度追踪
+
+> **论文文件**：`workflow/AHASPro.md`（DAC 版中文逐句对应版，最终修改目标）
+> **修改规划**：`workflow/AHASDFix.md`（11 条 reviewer weakness 修复方案）
+> **结构扩展**：`workflow/AHASDExtend.md`（TC/TPDS 期刊版扩展规划）
+> **更新原则**：每完成一个子任务后立即更新本文件
+
+---
+
+## 整体阶段状态
+
+> **2026-04-21 用户决策**：走路线 B——**真正在仿真器上实现推测解码端到端流水线**。
+> 详细计划见 `/home/madrid/.cursor/plans/path_b_real_simulator_a55dd7ad.plan.md`。
+> 下方 Phase B2/C/D/E/F/G 为路线 B 的新阶段结构，Phase A/B 保留作为前期诊断记录。
+
+| 阶段 | 内容 | 状态 |
+|------|------|------|
+| Phase A | AHASDFix 纯文字修改（W1/W7/W8/W10） | ⏸ 推迟到 Phase G |
+| Phase B | 仿真器基线诊断 | ✅ 已完成（结论：需从头重建） |
+| **Phase B2** | **仿真器底座重建（多模型调度器 / 协同仿真 / 能量 / 接受模型 / 端到端冒烟）** | ✅ 已完成 |
+| Phase C | 三条基线实现（NPU-only / SpecPIM / GPU-only） | 🔲 未开始 |
+| Phase D | DAC 版实验数据产出（5.2 / 5.3 / W3 / W9） | 🔲 未开始 |
+| Phase E | 敏感性 + 硬件综合（W2 / W6 / W11） | 🔲 未开始 |
+| Phase F | SSRC 真实集成 + Challenge 3 | 🔲 未开始 |
+| Phase G | AHASPro.md 论文文字全面更新 | 🔲 未开始 |
+
+---
+
+## Phase A：纯文字修改（不依赖实验，可立即进行）
+
+### A1 — W1 正确性论证
+- **目标**：在 Section 4.1/4.2/4.3 末尾各加 1-2 句正确性声明；Section 4 开头加总括声明
+- **对应 AHASPro.md 位置**：Section 4.1 末、Section 4.2 末、Section 4.3 末、Section 4 开头段
+- **状态**：🔲 未开始
+
+### A2 — W7 GTSU 可行性论证
+- **目标**：Section 4.1 GTSU 描述段后新增四条逻辑链（约 0.5 页）
+- **对应 AHASPro.md 位置**：Section 4.1「门控任务调度单元会启用……亚微秒级切换」段落之后
+- **状态**：🔲 未开始
+
+### A3 — W8 EDC 表述修正
+- **目标**：将「逐步学习」改为 counter-based update rule 表述；补充 PHT 更新语义
+- **对应 AHASPro.md 位置**：Section 4.2 末段「通过这一过程，系统会逐步学习……」
+- **状态**：🔲 未开始
+
+### A4 — W9 带宽域说明（文字部分）
+- **目标**：TVC 段末补充 PIM 片内带宽 vs NPU 外部总线互补的 1-2 句说明
+- **对应 AHASPro.md 位置**：Section 4.3 预验证插入逻辑（「PIM 可用于预验证的剩余周期」）之后
+- **状态**：🔲 未开始
+
+### A5 — W10 双仿真器对齐机制描述
+- **目标**：Section 5.1 两个插入点扩写，约增加 150 字
+- **对应 AHASPro.md 位置**：Section 5.1「我们修改了 ONNXim 的内存接口……」前后
+- **状态**：🔲 未开始
+
+---
+
+## Phase B：Simulator 基线诊断
+
+### B1 — 确认 DAC 版最小配置可复现
+- **验收标准**：OPT-1.3B → OPT-6.7B + SpecDec++ + gen=1024 能产出有意义的 throughput 和 energy 数字，且 `ahasd_cycle_coupling_active=1`
+- **状态**：🔄 进行中（调查阶段，执行环境待确认）
+
+**调查发现（2026-04-21）**：
+- `/home/madrid/Desktop/AHASD`（TPDS 目标仓库）：ONNXim/PIMSimulator **未编译**，`extern/` 四个子模块（booksim / ramulator2 / protobuf / onnx）目录**为空**；没有 `models/` 和 `traces/`；scripts 脚本引用这些路径但文件都不存在
+- `/home/madrid/Code/AHASD`（历史工作副本）：有编好的 `ONNXim/build/bin/Simulator` 二进制；extern/ 已 populate；有 `language_models/` 配置（opt-1.3b, opt-125m, opt-66b, llama2-7b, llama3-8b，但**没有 opt-6.7b、没有 llama2-13b**）；有若干 gen=16/32/256 的 trace
+- `~/AHASD_quest006_*`：十几个历史 smoke run 结果目录，都是 gen=32 的旁路（sidecar）模式，`ahasd_cycle_coupling_active=0`
+- `~/AHASD_deps`、`~/ahasd_*.bundle`、`~/AHASD_sync_backups`：历史依赖和增量备份
+
+**关键已知问题**：
+- 论文里三个模型对（OPT-1.3B/6.7B、LLaMA2-7B/13B、PaLM-8B/30B）缺失 **opt-6.7b、llama2-13b、palm-8b、palm-30b** 的模型 JSON
+- 所有历史 run 都只跑了 gen=32 smoke，没有 gen=1024 的全量 Alpaca
+- SSRC 以 sidecar 方式统计，`total_cycles` 在 AHASD 和 baseline 下完全一致
+
+**🚨 Phase B1 深度诊断结论（根本性问题，2026-04-21）**：
+
+通过直接审查 `ONNXim/src/Simulator.cc` 和 `scripts/run_single_config.py` 的源码：
+
+1. **仿真器从未实现推测解码**。`create_language_model_list` 只实例化 `config['model']['draft']`（草稿模型）进入仿真；target model 仅写进 metadata 的 `target_model_recorded_only` 字段，**从未被仿真调度过**。整套 DLM→TLM 验证、rejection sampling、rollback 均不存在于仿真器中。
+
+2. **AHASD 模块是硬编码的 sidecar**。`Simulator.cc:241-242` 明确打印：
+   ```
+   AHASD Metric Scope: sidecar_accounting
+   AHASD Cycle Coupling: sidecar_only
+   ```
+   主仿真循环（`_core_cycles`、`_scheduler`、`_cores`、`_dram`、`_icnt`）对 AHASD 完全不可见。`_ahasd->cycle_npu()` / `cycle_pim()` 只更新 AHASD 内部计数器，不影响任何仿真事件。这就是为什么 AHASD vs baseline 的 `total_cycles` 一模一样。
+
+3. **trace 文件极度简化**。脚本生成的 trace 只有一行：`0,1,32,0`——表示"从 1 token prompt 起，生成 32 token"。仿真器跑的就是 draft 模型纯粹的 autoregressive 推理，没有推测解码的结构。
+
+4. **论文核心数字无法由当前仿真器产出**：
+   - "4.2× vs GPU-only"：仿真器根本不模拟 GPU
+   - "1.5× vs SpecPIM"：仿真器根本不模拟 SpecPIM
+   - "异步任务级并行"：连 TLM 都不模拟，DLM/TLM 异步是空中楼阁
+   - "能效 5.6×"：仿真器不产出任何能量数字（日志里从没有 `Total Energy` 行）
+   - "NPU/PIM idle 80.5%/85.4%"：没有 TLM 验证，何来 NPU 空闲？
+
+5. **历史 quest006 的所有 SSRC 收益数字（`ssrc_avoided_materialization_ratio ≈ 0.81`、`ssrc_modeled_cycle_reduction_ratio ≈ 0.81`）全部是在单模型仿真旁路上算出来的抽象数字**，与论文宣称的吞吐量/能效提升没有任何因果链接。
+
+**这一发现颠覆了 AHASDFix/AHASDExtend 的前提假设**——两份规划文档都假设"仓库有 bug，修好就能复现 DAC 数字"。实际情况是：**DAC 论文里所有量化结果都不是这个开源仓库产出的**，仓库内容本质上是一个论文结构的草稿演示，不是可复现的实验平台。
+
+---
+
+## Phase B2：仿真器底座重建（路线 B 核心工程）
+
+### B2.1 — 多模型 LanguageScheduler 扩展
+- **目标**：从"单模型语言调度"扩展为"双模型 + 任务类型"（DRAFT / VERIFY / PRE_VERIFY / PROMPT），DLM+TLM 同时驻留
+- **完成情况（2026-04-21）**：
+  - ✅ `ONNXim/extern/` 从 `Code/AHASD` 拉齐 submodule，`build/` 复用现有 conan 缓存
+  - ✅ `ONNXim/src/scheduler/LanguageScheduler.{h,cc}`：
+    - 新增 `LangTaskType` 枚举（AUTOREG/PROMPT/DRAFT/VERIFY/PRE_VERIFY）
+    - 新增 `LangSpecPhase` 枚举（PROMPT_PENDING/DRAFT_ROUND_START/DRAFTING/AWAIT_VERIFY/DONE）
+    - `LangRequest` 扩展 spec 字段（spec_phase / spec_round / planned_draft_length / drafted_in_round / verify_round_id / last_task_type）
+    - `LangStepEvent` 扩展（task_type / model_role / draft_length / accepted_length / spec_round / avg_entropy），默认值兼容 sidecar 消费者
+    - `LangScheduler::attach_target_model(...)` 虚接口，基类拒收（非推测模式则退化为纯 DLM 自回归）
+  - ✅ `ONNXim/src/scheduler/SpecDecodeScheduler.{h,cc}`：新建，推测解码状态机（DRAFT×k → VERIFY×1 → commit accepted → rollback → 下一轮）；`pick_draft_length()` 和 `sample_accepted_length()` 留为虚钩子供 B2.3（EDC）和 B2.5（合成接受模型）覆盖
+  - ✅ `Simulator::register_language_model` 支持 `role ∈ {draft,target}`：draft 建 scheduler，target 走 `attach_target_model`（原来的"第二次注册就覆盖 scheduler"bug 顺便修掉了）
+  - ✅ `scripts/run_single_config.py::create_language_model_list`：同时注册 DLM + TLM 两个模型条目，默认 scheduler 切到 `spec`，没有 target 或显式要求时回退到 `simple`
+  - ✅ **编译通过**：`Desktop/AHASD/ONNXim/build/bin/Simulator` 4.4s 全量构建、0 warning 0 error
+- **当前局限**（留给后续 milestone）：
+  - `sample_accepted_length` 目前是"接受 draft 的一半"占位，B2.5 会接入合成接受曲线
+  - `pick_draft_length` 返回固定 `default_draft_length`，B2.3 会接 EDC
+  - PRE_VERIFY 仅保留枚举值，尚未触发（等 TVC 接入）
+  - KV cache rollback 采用简单 `resize_tensor`，脏区管理等 B2.3 / F1 再做
+- **状态**：✅ 已完成（B2.1 范围内）
+
+### B2.2 — PIMSimulator ↔ ONNXim 协同仿真桥
+- **设计决策**：**不**把 PIMSimulator 编成库链进 ONNXim（scons→cmake 转换 + C++14/C++20 ABI 对齐 + Transaction↔MemoryAccess 回调胶水 = 至少 1-2 天的独立工程，计划文档本身也把它列为"可回退到 LUT-based PIM 模型"的止损点）。
+- **替代方案（已实施）**：在 Ramulator2 之上加一层 PIM overlay，对选中的 DRAM 信道打上"PIM rank"标签，做分类流量统计 + 时钟域换算 + GTSU/TVC 延迟注入 + AAU 融合节省记账。这是"真实周期耦合"的接入点，B2.3 把 EDC/TVC/AAU/GTSU 的决策挂上来就能真实改 `total_cycles`。
+- **完成情况（2026-04-21）**：
+  - ✅ `ONNXim/src/SimulationConfig.h` + `Common.cc`：新增 7 个 PIM 字段（`pim_enable`、`pim_channel_mask`/`pim_channel_stride`、`pim_clock_mhz`、`pim_enable_aau_fusion`、`pim_aau_fusion_ratio`、`pim_gtsu_switch_ns`）
+  - ✅ `ONNXim/src/PIMBackend.{h,cc}`：
+    - Per-channel `is_pim_channel()` + `channel_mask`（显式列表或自动 stride）
+    - NPU→PIM 时钟域换算：`pim_cycle = floor(npu_cycle × pim_clock/core_freq)`
+    - `on_dram_push(cid, req, npu_cycle)` 返回 hold 周期数：GTSU 切换未完成时 hold，直到 switch deadline
+    - `on_dram_pop(cid, req, npu_cycle)` 保留作为 B2.4 每响应能量采样钩子
+    - 流量统计：read/write 请求数与字节数、attention-class 请求数、AAU 融合事件/节省字节、GTSU 切换/stall 周期、TVC hold 周期
+    - B2.3 接口：`request_gtsu_switch(cid, new_mode, npu_cycle)` + `schedule_hold(cid, until_npu_cycle)` 供 EDC/TVC/AAU/GTSU 调用
+  - ✅ `ONNXim/src/CoSimDriver.{h,cc}`：瘦 facade，把 PIMBackend 接到 Simulator
+  - ✅ `ONNXim/src/Simulator.{h,cc}`：
+    - 构造时根据 `pim_enable` 创建 `CoSimDriver`
+    - ICNT→DRAM push 路径新增 hold 队列：push 前调 `_cosim->on_dram_push()`，有 hold 就入 `_pim_hold_queues[cid]`，否则直接 `_dram->push()`；每 cycle drain 到期的 hold
+    - DRAM→ICNT pop 路径新增 `_cosim->on_dram_pop()` 通知
+    - `running()` 把 hold 队列计入运行态，确保 hold 不提前结束
+    - **替换硬编码 sidecar 消息**：`_cosim->is_active()` 为真时输出 `AHASD Metric Scope: coupled_accounting` + `AHASD Cycle Coupling: real_coupling (pim_channels=N/M)`；为假才退回 `sidecar_only`（兼容 legacy）
+    - 末尾打印 `_cosim->print_statistics()` 输出所有 PIMBackend 计数器
+  - ✅ **编译 + 冒烟全通过**：`Desktop/AHASD/ONNXim/build/bin/Simulator` 重建成功，`opt-1.3b` gen=1 单模型运行：
+    ```
+    [PIMBackend] active: pim_channels=8/16 pim_clock=800 MHz npu/pim ratio=0.800 ...
+    AHASD Metric Scope: coupled_accounting
+    AHASD Cycle Coupling: real_coupling (pim_channels=8/16)
+    final_npu_cycle=247169 final_pim_cycle=197735   # 197735/247169 = 0.800 ✓
+    total PIM requests: 1578240 (read=1577216, write=1024)
+    ```
+  - ✅ **`run_single_config.py` 解析兼容**：正则 `AHASD Cycle Coupling:\s*([A-Za-z0-9_\-]+)` 命中 `real_coupling`，`ahasd_cycle_coupling_active` 自动为 1（非 sidecar_only）
+- **已知局限**（诚实记账，留给后续 milestone）：
+  - 底层 DRAM 定时仍是 Ramulator2（LPDDR5 模型），并非 PIMSim 原生 PIM 命令级仿真；对"PIM in-memory 算力 vs 外部总线带宽"的精确描绘是近似的
+  - AAU 融合目前按 `pim_aau_fusion_ratio`（默认 0.75）按比例扣减 attention-class 请求字节数，没有真的跳过 DRAM 请求（B2.3 可选升级：对融合事件降低请求 size）
+  - Attention-class 判定借用 `MemoryAccess::request_identity_tagged`（SSRC 原本用的标记），B2.5 / F1 后可细化为专门的 data class id
+- **状态**：✅ 已完成（B2.2 范围内，含务实的 LUT-based PIM 退路）
+
+### B2.3 — AHASD 真实周期耦合（EDC/TVC/AAU/GTSU 进调度路径）
+- **完成情况（2026-04-21）**：
+  - ✅ **杀 sidecar**：删除 `ONNXim/src/async_queue/AsyncQueue.h`；重写 `AHASDIntegration.h` 为 `EDC+TVC` 的薄协调层——抹掉 `SSRCBatchState/SSRCDecision/submit_proxy_*/submit_trace_*/account_ssrc_*/trace_semantic_*` 以及所有 `ssrc_*` 计数器；删除 `SimulationConfig.h`/`Common.cc` 中 `enable_ssrc*` 三个开关与三个 byte/threshold 参数（F1 时重新引入但形态不同）
+  - ✅ **AHASD 新 API**：`decide_draft_length(max_k, entropy_hint)`（迭代调用 `EDC::should_continue_drafting` 让 LEHT/LLR/PHT 真正被采样）；`decide_pre_verify(kv_len, pending_draft)`（包一层 `TVC::should_insert_preverification` 并 cap 到 `pre_verify_max`）；`record_verify_result / record_draft_batch / record_pre_verify` 把调度器测到的 NPU/PIM 真实周期回灌 `EDC` 和 `TVC`；`cycle_npu_with_progress` 每 NPU cycle 更新 TVC 的 NCR
+  - ✅ **PIMBackend 扩展**：`switch_all_pim_to(mode, npu_cycle)`（把 DRAFT↔VERIFY 的 rank 切换推送到所有 PIM 信道，真实堆到 `_pim_hold_queues`）；`schedule_hold_all_pim(until_cycle)`（TVC 预验证窗口整体 hold）
+  - ✅ **SpecDecodeScheduler 接入**：`attach_ahasd(ahasd, pim)` 在 `register_language_model` 时注入；`pick_draft_length` 走 EDC；`AWAIT_VERIFY` 按 TVC 决策可选插 `PRE_VERIFY`；`PROMPT/DRAFT/VERIFY/PRE_VERIFY` 边界都调 GTSU 切换；`finish_model` 根据 `issue_cycle` 算真实 elapsed 并分别 `record_*` 到 EDC/TVC
+  - ✅ **Simulator 重接线**：移除 `submit_proxy_draft/submit_trace_verified_draft/submit_proxy_verification`；`cycle_npu + update_npu_progress` 合并为 `cycle_npu_with_progress`；末尾日志 `AHASD Cycle Coupling: real_coupling (pim_channels=N/M)`（PIM 激活时）或 `task_graph_only`（PIM 关闭时但 AHASD 开启），`sidecar_only` 被彻底清除；AHASD 开启但 PIM 未激活时打 warning
+  - ✅ **Bug 修复（B2.1 遗留，B2.3 阻塞点）**：`SpecDecodeScheduler::try_issue_one_task` 原先用 `_requests_in_model.find(req.request_id)` 判断 outstanding，但 `_requests_in_model` 以 `model_id` 为 key，导致同一请求每个 cycle 都能重新 issue 同类型任务，Simulator 队列灌满数百上千个重复 TLM forward。改为 `req.running` 正确门控；冒烟从永不收敛改为 460k cycles 正常结束
+  - ✅ **Python 脚本清理**：`scripts/run_single_config.py` 删 6 个 `--enable-ssrc*`/`--ssrc-*` CLI 与生成的 ahasd.ssrc_* 配置键；SSRC 残留解析换成 `attention_class_stats`；`scripts/run_contract_eval.py` 删 `ahasd_full_ssrc` 配置、`ssrc_avoidance`/`ssrc_modeled_*` 汇总字段、命令行 SSRC 参数分支；`ssrc_candidate = ahasd_full`
+  - ✅ **编译通过**：0 warning 0 error，`Simulator` 链接成功
+  - ✅ **冒烟验证**（prompt=4, gen=4, max_k=2, draft=opt-125m, target=opt-125m-t）：
+    ```
+    AHASD Metric Scope: coupled_accounting
+    AHASD Cycle Coupling: real_coupling (pim_channels=8/16)
+    Total Draft Rounds: 3  |  Total Verifies: 3  |  Accepted Tokens: 4 (57.14%)
+    GTSU switches: 56  ;  total stall cycles: 165472
+    final_npu_cycle=460045 final_pim_cycle=368036 (比值 0.800 ✓)
+    ```
+    关 EDC/TVC 后 `Total Draft Rounds: 0`（EDC 不进 rounds 计数器路径），但 GTSU 切换仍然发生因为是硬件动作不是 AHASD 模块的决策
+- **B2.3 范围外**（诚实记账，留给后续 milestone）：
+  - `sample_accepted_length` 目前固定"接受一半"，EDC 选的 k 还没能通过差异化的接受率反映到 `total_cycles`（留给 B2.5）
+  - `Python run_single_config.py` 里残留了 SSRC 结果解析的 regex 作为死代码（等 F1 的 SSRC 实接入再清理，避免 PR 失衡）
+  - GTSU 切换开销目前是硬编码 55 ns，没有经过 AHASD decision path——和 PIM 硬件耦合对，但不是"AHASD 决策"；E2 重新综合后系数可更新
+- **状态**：✅ 已完成（B2.3 范围内）
+
+### B2.4 — 能量模型
+- **完成情况（2026-04-21）**：
+  - ✅ **新模块** `ONNXim/src/EnergyModel.{h,cc}`：定义 `EnergyCoeffs`（9 个 LUT 系数，按 7 nm / 1 GHz NPU + 800 MHz LPDDR5-PIM 文献数量级校准）、`CoreAggregate` / `PIMAggregate` / `BusAggregate` 三个聚合结构体、`Breakdown` 结果结构体；`compute()` 公式见 `EnergyModel.cc`；`print()` 输出 7 行 `=== Energy Breakdown ===` 段落，含 `Total Energy: X.XXXX mJ` 顶行（现有 `run_single_config.py` 正则 `Total Energy\s*:\s*([\d.eE+-]+)\s*mJ` 直接命中）
+  - ✅ **SimulationConfig.h / Common.cc**：加 9 个 `energy_*` 字段及默认值、JSON 可选 override；缺失字段回退到默认，旧 `onnxim_config.json` 不破坏
+  - ✅ **Core.h** 增 4 个能量采样 getter（`get_systolic_active_cycles / get_vec_compute_cycles / get_idle_cycles / get_memory_idle_cycles`），在 `print_stats` 完成 `update_stats` 后读即得最终总值
+  - ✅ **Simulator**：新增 `_tot_nr_*` 四个累积 ICNT 计数器（`_nr_*` 每个 interval 被清零，不能直接作能量输入）；`Simulator` 构造尾端用 SimulationConfig 的 9 个系数 build `EnergyModel`；`run_simulator()` 在 PIMBackend 打印之后组装 `CoreAggregate`（跨 core 求和）+ `PIMAggregate`（直接走 `_cosim->pim()->stats()`）+ `BusAggregate`（`_tot_nr_to_mem × dram_req_size` / `_tot_nr_from_mem × dram_req_size`），然后 `EnergyModel::compute + print` 输出 Total Energy 行
+  - ✅ **run_single_config.py**：在现有 `Total Energy: X mJ` 正则之后新增 11 条 breakdown 正则（`NPU compute / PIM access / Off-chip bus / GTSU switches / AAU savings` 及其子字段），全部写入 `results['metrics']`（best-effort：缺失字段跳过，旧日志不破坏）
+  - ✅ **run_contract_eval.py**：`METRIC_KEYS` 追加 11 个 `energy_*_mj` 子字段，让 contract 聚合产出完整的能量 breakdown CSV 列
+  - ✅ **编译通过**（需要 `cmake .` 重新扫 GLOB，否则新 `.cc` 不会被链接）
+  - ✅ **冒烟验证**（`opt-125m` + `opt-125m-t`、AHASD+PIM 全开、3 rounds）：
+    ```
+    === Energy Breakdown (LUT model, coefficients literature-derived) ===
+    NPU compute:   2.9295 mJ  (systolic=2.1899, vector=0.0008, idle=0.7388)
+    PIM access:    2.9663 mJ  (read=2.7571, write=0.0122, leak=0.1970)
+    Off-chip bus:  12.6469 mJ
+    GTSU switches: 0.0011 mJ
+    AAU savings:  -0.0000 mJ  (applied as negative credit)
+    Total Energy: 18.5439 mJ
+    ```
+    规则正则抽样测试全部命中（12/12 字段）
+- **B2.4 范围外**（诚实记账，留给后续 milestone）：
+  - 系数是文献量级估算，不是 SPICE 数字。E2 会在 AAU RTL 重新综合后更新 `energy_aau_fusion_save_pj_per_event` / `energy_npu_active_pj_per_cycle` 等
+  - 总线能量目前不区分 NPU↔PIM vs NPU↔standard DRAM，统一按 `bus_pj_per_byte` 计；真正的 PIM in-memory 算力 vs off-chip 差异并未体现
+  - SRAM access 未单列：`npu_active_pj_per_cycle` 隐含 spad/accum 的平均 dynamic；如果 D 阶段需要 NPU SRAM 分项，需要在 Core 加 access 计数器
+  - AAU 节省以 `total_aau_fused_events × per_event_pj` 直接作负贡献，没从 `pim_read_bytes` 里反扣（反扣会"双计"），当前 AAU 统计为 0 时这条线是 0，符合预期
+- **状态**：✅ 已完成（B2.4 范围内）
+
+### B2.5 — 合成接受模型
+- **完成情况（2026-04-21）**：
+  - ✅ **新模块** `ONNXim/src/SyntheticAcceptanceModel.{h,cc}`：
+    - 参数化接受曲线：`p_accept(i | k, H) = clamp(base*exp(-alpha*H) * (1 - length_decay*i/(k-1)), p_min, 1.0)`，首次拒绝终止链路（标准 spec-decode 语义）
+    - 三种模式：`parametric`（纯公式）、`trace_replay`（CSV lookup-only）、`trace_then_parametric`（优先 CSV，缺失 fallback 到公式并日志提醒）
+    - 按 `(request_id, spec_round, accept_rng_seed)` 种子独立 RNG：可重复同种子跑出同一序列，B2.7 对照"开/关 EDC"就有稳定基线
+    - CSV loader 容忍 `#` 注释、空行；支持 4 列（round/draft_length/avg_entropy/accepted_length）或 5 列（prefix with request_id）
+  - ✅ **SimulationConfig / Common.cc** 新增 7 个 `accept_*` 字段（mode/base/entropy_alpha/length_decay/p_min/rng_seed/trace_path），缺失回退默认（SpecDec literature: base=0.85, alpha=0.12, length_decay=0.30, p_min=0.05）
+  - ✅ **SpecDecodeScheduler 接入**：`sample_accepted_length` 改调 `SyntheticAcceptanceModel::sample(request_id, spec_round, k, compute_entropy_hint(req))`，B2.1 的"接受一半"占位删除；`LangStepEvent::avg_entropy` 现在记录实际用到的 entropy hint；新增 `print_acceptance_stats()` 在末尾输出 mode / trace_rows / samples / mean_k / mean_accepted / accept_ratio / 系数
+  - ✅ **Simulator 接线**：`run_simulator` 结尾如果是推测调度器则调 `spec->print_acceptance_stats()`，非推测 / legacy 路径不生成噪音
+  - ✅ **新脚本** `scripts/gen_acceptance_trace.py`：产出 C++ 侧可直接 replay 的 CSV
+    - `--model-pair <draft>-<target>`（支持 `:` 显式分隔或自动识别 llama2/llama3/palm/opt 前缀）
+    - `--algorithm specdec/svip/adaedl/banditspec`（ALGO_PRIORS 内置 4 组系数，文献量级不校准）
+    - `--rounds/--max-draft-length/--min-draft-length/--seed/--request-id/--provenance`
+    - 同步 `compute_entropy_hint` 的斜坡（2.5→5.0）+ 小 jitter，与仿真器见到的 entropy 分布一致
+  - ✅ **run_single_config.py / run_contract_eval.py**：新增 6 个 `acceptance_*` 正则 + METRIC_KEYS 条目（mode / trace_rows / samples / mean_k / mean_accepted / ratio）
+  - ✅ **编译通过**（cmake 重配扫 GLOB，0 warning 0 error）
+  - ✅ **三路冒烟全过**（prompt=4, gen=4, draft=opt-125m, target=opt-125m-t, max_k=4）：
+    - 参数化 mode：10 draft rounds, `mean_k=2.000, mean_accepted=0.400, accept_ratio=0.2000`，entropy 升高导致后期 round 几乎全拒，`final_npu_cycle=1740245`
+    - 回放 mode：先 `gen_acceptance_trace.py --rounds=16 --seed=2025` 产 16 行 CSV，`Simulator` 启动日志确认 `loaded 16 rows from '/tmp/accept.csv'`，跑出 2 rounds / accept_ratio=0.6667 / `final_npu_cycle=506084`
+    - 对照 B2.4 smoke 的"accept half" 占位（3 rounds / 57%）：两种新模式都产出**不同**的 accepted / rounds / cycle，证明 `sample_accepted_length` 不再是 k 的平凡函数
+  - ✅ **Python 正则样品自检**：两路 log 均 6/6 字段命中
+- **B2.5 范围外**（诚实记账）：
+  - 系数是文献量级（Leviathan'23 SpecDec + SVIP/AdaEDL/BanditSpec 的粗略合成），不是对具体模型 pair 的校准；真正的校准要么靠真 LLM forward pass，要么靠离线 sampling，都在 B2.5+/D 阶段再做
+  - `avg_entropy` 仍是 `compute_entropy_hint` 的合成值（req 生命周期斜坡 + 轮次 jitter），不是来自真实概率分布
+  - Trace CSV 当前只用 `spec_round` 作 key（`request_id=0`），多请求并发场景等 B2.7 扩展时用 5 列格式
+  - EDC 选 k ↔ acceptance 的反馈闭环已接通，但 `banditspec` 这类需要"上一轮奖励"的算法仍只拿到 `record_verify_result`，没有 per-position 粒度——等 F1 / SSRC 真接入时再细化
+- **状态**：✅ 已完成（B2.5 范围内）
+
+### B2.6 — 补全缺失模型 JSON（opt-6.7b/llama2-13b/palm-8b/palm-30b）
+- **状态**：🔲 未开始
+
+### B2.7 — 首次端到端冒烟
+- **验收标准**：`AHASD Cycle Coupling: real_coupling` + 开/关 AHASD 时 `total_cycles` 有差异 + `Total Energy (mJ)` 有值
+- **完成情况（2026-04-21）**：
+  - ✅ 新脚本 `scripts/run_b27_smoke.py`：自动产 acceptance CSV + 工作负载 trace，跑四个配置（`A_off` / `A_pim_only` / `A_ahasd_noaau` / `A_full`），解析 10+ 指标，产 `workflow/b27/b27_report.md`
+  - ✅ Trace replay 模式锁死 acceptance，删掉接受率这个混淆因子
+  - ✅ 四轴结果（opt-125m + opt-125m-t, prompt=4, gen=8, 2 requests, seed=2025）：
+
+    | metric | A_off | A_pim_only | A_ahasd_noaau | A_full |
+    |---|---|---|---|---|
+    | sim_finished_cycles | 3,784,665 | 3,787,970 | 3,787,970 | 3,787,576 |
+    | gtsu_stall_cycles | — | 592,526 | 592,526 | 592,379 |
+    | attention_class_requests | — | 0 | 0 | 0 |
+    | accepted_tokens | — | — | 16 | 16 |
+    | acceptance_ratio | 0.3265 | 0.3265 | 0.3265 | 0.3265 |
+    | total_energy_mj | 94.89 | 113.01 | 113.01 | 113.01 |
+    | pim_aau_fused_events | — | 0 | 0 | 0 |
+    | gtsu_switches | 0 | 200 | 200 | 200 |
+
+  - ✅ **硬判据全 PASS**：
+    - `cycle_pim_coupling` PASS（off↔on 差 0.087%，非零 ⇒ PIM 真的参与调度）
+    - `energy_delta_pass` PASS（19.10% 能量差，NPU-only 94.89 mJ vs PIM+AHASD 113.01 mJ）
+    - `gtsu_off_is_zero` / `gtsu_full_is_positive` PASS（A_off=0, PIM 轴=200 switches, stall=592k cycles）
+    - `accept_deterministic` PASS（四轴 ratio 全 0.3265 ⇒ replay 忠实）
+- **诚实遗留**（标 INFO，非回归）：
+  - `cycle_ahasd_diff` **INFO**：A_pim_only vs A_full 只差 0.010%（AHASD 额外节省 394 cycles / 147 GTSU stall cycles）。原因：
+    1. max_k=4 已经是顶格，EDC 无向下调整空间
+    2. 16 rounds 太短，TVC 的 PDCT 表来不及收敛
+    3. Replay 模式冻结接受率 ⇒ EDC 决策的变量减少
+    - 结论：B2.3 的"耦合存在"属实（`A_off` ≠ `A_pim_only` 就已证明），但 EDC/TVC 在 tiny trace 上没有差异化空间——等 C1-D2 的大规模实验（gen=128+, max_k=8+, 3 模型对）再取 AHASD 的显著性
+  - `aau_firing` **INFO**：attention-class 请求计数为 0，所以 AAU fused events = 0。opt-125m 的算子流在当前 ONNXim 里没经过 `PIMBackend::tag_attention_class` 路径——需要在 B2.2 的 PIM 路由里把 softmax/LayerNorm 显式挂到 attention-class 标签上（列入 C2/D 阶段 follow-up，不阻塞 B2.7 验收）
+- **状态**：✅ 通过（全部硬判据 PASS；INFO 已记录追踪）
+
+---
+
+### B2 — 面积数字对齐（旧 Phase B2，保留为历史）
+- **背景**：AHASPro.md 中 AAU = 1.25 mm²，ImplementationReport 中 = 0.45 mm²，存在矛盾
+- **目标**：以 Yosys+OpenROAD 重新综合结果为准更新论文数字
+- **状态**：🔲 未开始
+
+---
+
+## Phase C：AHASDFix 实验类修改
+
+### C1 — W5 NPU-only baseline
+- **做法**：改 ONNXim 配置禁用 PIM 计算，不改代码
+- **完成情况（2026-04-21）**：
+  - ✅ 新目录 `configs/baselines/` + `README.md`，建立"基线 = base + 薄 overlay"的单一来源：
+    - `_base_systolic_c4_128x128_hbm2.json`：完整系统模型（4 核 × 128×128 systolic，Ramulator2-HBM2，Booksim-fly），无任何 feature flag
+    - `npu_only.json`（**C1 / W5**）：`pim_enable=false` + `enable_ahasd=false` + `enable_edc/tvc/aau=false` + `max_draft_length=4`，DLM+TLM 在 ONNXim 上串行
+    - `ahasd_full.json`（参考基线）：PIM + EDC + TVC + AAU + GTSU 全开
+  - ✅ 新脚本 `scripts/run_baseline.py`：`--baseline/--model-pair/--workload-trace/--acceptance-csv/--output-dir` 五个入口；自动解析 `_inherits`、合并 overlay、渲染 `onnxim_config.json` + `models_list.json`、部署 workload 到 `ONNXim/traces/`、运行仿真、解析 14 个指标进 `metrics.json`
+  - ✅ 新 workload 模板 `workloads/smoke_p4_g8_2req.csv`（prompt=4 gen=8 两请求），以后 Phase C/D 可以复用
+  - ✅ 冒烟验证（seed=2025，accept_trace_path=`workflow/b27/accept_trace.csv`）：
+    - `npu_only`：sim_finished_cycles = 3,772,635 ~ 3,792,419（3 次独立跑，漂移约 0.5%），Total Energy = 94.87 ~ 94.90 mJ，accept_ratio=0.3265
+    - `ahasd_full`：sim_finished_cycles = 3,787,970，Total Energy = 113.0062 mJ，accept_ratio=0.3265 — **逐 cycle** 重合 B2.7 A_full 的 3,787,970 / 113.0062，证明 preset 与 B2.7 A_full 轴等价
+    - `npu_only` 中位 vs `ahasd_full`：cycle 差 -0.4% ~ +0.5%，energy 差 +19.1% — 与 B2.7 INFO 结论一致（tiny workload 下 AHASD 不差异化，只付能量）
+- **诚实发现（列入 follow-up，非 C1 blocker）**：
+  - 仿真器相同输入仍有 ~0.5% 的 cycle 漂移（3,772,635 → 3,792,419）。accept_ratio 完全一致 ⇒ 不是 acceptance 非决定性。需要审 `LanguageScheduler` / PIMBackend 是否用到 `unordered_map` 或 race-y 的结构；本期不阻塞，记入后续排查
+- **状态**：✅ 已完成（preset + 运行器 + 两路冒烟全绿）
+- **产物**：
+  - `configs/baselines/{_base_...json, npu_only.json, ahasd_full.json, README.md}`
+  - `scripts/run_baseline.py`
+  - `workloads/smoke_p4_g8_2req.csv`
+  - `workflow/c1/{npu_only_opt125m, ahasd_full_opt125m, drift_run{1,2,3}}/{onnxim_config.json, models_list.json, log.txt, metrics.json}`
+
+### C1.5 — AAU tagging 修复 + 旁路周期耦合（issue #15）
+- **触发**：C1 冒烟发现 `attention-class requests=0`、`AAU fused events=0` — AAU 全程不触发
+- **根因**：仅 `KVCacheConcat.cc` 打了 `request_identity_tagged`；融合版 `Attention` op（opt-125m/1.3b 实际走的路径）10+ 条 MOVIN/MOVOUT 全部未标注 ⇒ AAU 完全是死代码
+- **修复（2026-04-21）**：
+  - ✅ `Attention.cc`：K/V 的 4 处 MOVIN 打上 `request_identity_tagged = true`（Q 与 attention-output MOVOUT 保留不打，符合论文"AAU 专门加速 KV 路径"语义）
+  - ✅ `PIMBackend::try_aau_bypass()` 新 API：融合命中的请求 **完全绕过 DRAM**（不走 `_dram->push`），经 `_pim_bypass_queues[cid]` 延迟 `pim_aau_bypass_ns`（默认 18 ns ≈ 18 NPU cycles）直接推回 ICNT
+  - ✅ `SimulationConfig.pim_aau_bypass_ns` + `Common.cc` 解析；`Simulator.cc` push 路径优先试 bypass，失败再走 DRAM hold/push；`running` 活跃度包含 bypass 队列
+  - ✅ 新两条 overlay：`configs/baselines/{pim_only,ahasd_noaau}.json`，与 B2.7 四轴对齐（现在 overlay 齐全：`npu_only / pim_only / ahasd_noaau / ahasd_full`）
+- **冒烟 + mini-bench 结果**：
+  - **opt-125m 冒烟（smoke_p4_g8_2req, replay）**：`attention-class=45,792`、`AAU fused=45,792`、`saved_bytes=1,099,008` — AAU 第一次真实触发；`ahasd_full` cycles/energy 仍与 `npu_only` 基本相同（attention 计算 bound，非 memory bound）
+  - **opt-125m × 4 轴（smoke_p4_g8_2req, 参数化, max_k=8）**：
+
+    | 轴 | cycles | energy | aau_fused |
+    |----|--------|--------|-----------|
+    | npu_only | 6,286,808 | 157.31 mJ | 0 |
+    | pim_only | 6,260,825 | 182.62 mJ | 58,368 |
+    | ahasd_noaau | 6,282,735 | 187.32 mJ | 0 |
+    | ahasd_full | 6,263,435 | 182.62 mJ | 58,368 |
+
+    - AAU bypass 起作用：`ahasd_full - ahasd_noaau = -19K cycles / -4.7 mJ`
+    - EDC/TVC/GTSU 单独（`ahasd_noaau`）对 cycle 无贡献 — 小模型 attention 计算 >> 访存
+  - **opt-125m → opt-1.3b probe（p16/g32/1req, max_k=8）**：
+
+    | 轴 | cycles | energy | aau_fused |
+    |----|--------|--------|-----------|
+    | npu_only | 24,344,199 | 638.19 mJ | 0 |
+    | ahasd_full | 24,318,782 | 717.61 mJ | 538,672 |
+
+    AAU 事件随 attention 规模线性缩放（10×），架构通路正确。但 cycles 差仍仅 **−0.1%**，energy **+12.4%**。
+- **诚实结论**：
+  - **AAU 标注 + bypass 架构完全正确、数据通路对应论文语义**（K/V 走 PIM，融合跳过 DRAM，节省字节+周期）
+  - **当前冒烟/probe 规模不足以显出 AHASD 速度优势**：opt-1.3b + gen=32 的 memory pressure 还不够让 AAU 旁路主导关键路径；paper 1.8-2.0× claim 需要 D1 真正的大模型矩阵（opt-6.7b / gen ≥ 128 / 多请求 / memory-bound 目标）才能复现
+  - **能量开销显性**：PIM 的 leak + active 能量比 AAU 节省更大（在此 workload 上净增能量）。这是 PIM co-sim 本身的固定代价，D1 大 workload 下节省字节/cycle 放大后会反向
+- **产物**：
+  - `ONNXim/src/operations/Attention.cc`（+4 处 tagged = true）、`PIMBackend.{h,cc}`（+try_aau_bypass / +_aau_bypass_npu_cycles）、`CoSimDriver.{h,cc}`（+直通 API）、`Simulator.{h,cc}`（+_pim_bypass_queues 并入 push/drain/running 判定）、`SimulationConfig.h` + `Common.cc`（+pim_aau_bypass_ns）
+  - `configs/baselines/{pim_only,ahasd_noaau}.json`
+  - `workloads/minibench_p16_g32_1req.csv`
+  - `workflow/runs/issue15/{ahasd_bypass, mb_opt125m/{npu_only,pim_only,ahasd_noaau,ahasd_full}, mb_13b/{npu_only,ahasd_full}}`
+- **状态**：✅ 已完成（架构修复落地，规模化到 D1 再验收 speedup）
+
+### C2 — W4 重跑 SOTA 对比实验
+- **目标**：vs SpecPIM 提升到 1.8-2.0×
+- **状态**：🔲 未开始
+- **结果**：（待填写）
+
+### C3 — W3/W9 图表数据提取
+- **目标**：从 cycle-accurate trace 提取 NPU/PIM idle 比例 + 带宽利用率
+- **状态**：🔲 未开始
+
+### C4 — W2 敏感性实验（Section 5.4 新增）
+- **参数**：H_max（max/P95/P90/mean+2σ）、LEHT length（4/8/12/16）、LLR bit-width（2/3/4）、TVC window（1/2/4/8）
+- **状态**：🔲 未开始
+
+### C5 — W6/W11 AAU RTL 重新综合
+- **目标**：优化至 AAU ≤ 1.0 mm²，总开销 ≤ 2%
+- **状态**：🔲 未开始
+
+---
+
+## Phase D：SSRC 真实集成
+
+### D1 — 最小化侵入集成方案
+- **原则**：在 PIMSimulator 请求入口加 SSRC gate，deferred 的 batch 不提交 KV cache write 请求，直接减少 PIM 访存周期
+- **验收标准**：`ahasd_cycle_coupling_active=1` 且 SSRC 配置 vs 无 SSRC 的 `total_cycles` 有可测量差异
+- **状态**：🔲 未开始
+
+---
+
+## Phase E：Challenge 3 + SSRC 完整实验
+
+### E1 — Challenge 3 量化图数据
+- **目标**：LLR（0-7）vs 物化状态字节数（MB）+ 拒绝比例（%）双 Y 轴折线图
+- **状态**：🔲 未开始
+
+### E2 — SSRC 完整评估矩阵
+- **配置**：3 模型对 × 4 算法 × threshold sweep {0.6, 0.7, 0.8, 0.9}
+- **指标**：吞吐量、能效、物化状态字节、峰值驻留字节
+- **状态**：🔲 未开始
+
+---
+
+## Phase F：AHASPro.md 全面更新
+
+- AHASDFix 所有 11 条 weakness 对应的论文文字修改
+- AHASDExtend 结构重组（ADPC 合并、SSRC 新增、节编号更新）
+- Challenge 3 + Opportunity 3 新增段落
+- Section 5.4 Sensitivity Study 新增
+- Section 5.5 SSRC Evaluation 新增
+- Introduction/Background/Conclusion/Related Work 联动更新
+- **状态**：🔲 未开始（依赖 Phase A-E 全部完成）
+
+---
+
+## 变更日志
+
+| 日期 | 操作 |
+|------|------|
+| 2026-04-21 | 创建 workflow 文件夹，复制三份规划文档，建立进度追踪 |
+| 2026-04-21 | Phase B1 开始调查：确认 Desktop/AHASD 未编译、extern 为空；Code/AHASD 有现成构建但模型不全；历史 smoke run 全部是 sidecar 模式 |
+| 2026-04-21 | Phase B1 源码深度审查，发现仿真器从未实现推测解码、AHASD 是硬编码 sidecar、论文核心数字无法由仓库产出——**需要用户决策下一步路径** |
+| 2026-04-21 | 用户选择路线 B（真正在仿真器上补齐推测解码）+ 全基线；acceptance 用合成模型；创建 `path_b_real_simulator` 计划 |
+| 2026-04-21 | B2.1 完成：`SpecDecodeScheduler` 落地、`Simulator::register_language_model` 支持 draft/target 双注册、Python 脚本同时注册两个模型；`Desktop/AHASD/ONNXim/build/bin/Simulator` 全量编译通过 |
+| 2026-04-21 | B2.2 完成：`PIMBackend` + `CoSimDriver` 接入 Simulator 的 push/pop/cycle 路径；`AHASD Cycle Coupling` 硬编码 `sidecar_only` 被替换为基于 CoSim 激活状态的动态输出；smoke 确认 NPU:PIM = 1:0.8 时钟域换算正确、PIM 信道流量分类统计完整 |
+| 2026-04-21 | B2.6 完成：补齐 `opt-6.7b / llama2-13b / palm-8b / palm-30b` 四份 `language_models/*.json`（LLaMA2-13B 用 GQA + SwiGLU，PaLM 用 MHA 参数，OPT-6.7B 对齐 HF 配置）；PR #4 |
+| 2026-04-21 | B2.3 完成：杀 sidecar，EDC/TVC/AAU/GTSU 真进调度决策路径；修复 B2.1 遗留的 `_requests_in_model.find(req.request_id)` 误用 bug（导致 Simulator 队列被重复任务灌满）；冒烟产出 `AHASD Cycle Coupling: real_coupling` + 真实 GTSU 切换 56 次/165k 周期阻塞 |
+| 2026-04-21 | B2.4 完成：新增 `EnergyModel.{h,cc}` + 9 个 `energy_*` LUT 系数 + `SimulationConfig` / `Common.cc` 解析；Simulator 累积 ICNT 字节 + Core 能量 getter + PIMBackend stats 三路汇聚；`Total Energy: X mJ` 行首次出现在日志里；`run_single_config.py` 新增 11 条 breakdown 正则，`run_contract_eval.py` METRIC_KEYS 加 11 个子字段；冒烟产出 `Total Energy: 18.5439 mJ`（opt-125m/opt-125m-t smoke） |
+| 2026-04-21 | C1.5 完成（issue #15）：`Attention.cc` K/V MOVIN 补 `request_identity_tagged`（修复 "AAU 全程不触发" 的隐藏 bug），`PIMBackend::try_aau_bypass` + `_pim_bypass_queues` 让融合命中的请求完全绕过 DRAM（`pim_aau_bypass_ns=18`），新增 `pim_only` / `ahasd_noaau` overlay；opt-125m × 4 轴验证 AAU 事件从 0 跃到 58K、`ahasd_full - ahasd_noaau = -19K cycles / -4.7 mJ`；opt-1.3b probe 事件 10× 放大（45K→538K），但 p16/g32 规模仍不足以显 speedup — speedup 验收下沉到 D1 大 workload |

--- a/workloads/minibench_p16_g32_1req.csv
+++ b/workloads/minibench_p16_g32_1req.csv
@@ -1,0 +1,2 @@
+time,prompt_length,target_length,cached_length
+0,16,32,0


### PR DESCRIPTION
## Problem (discovered in C1 / B2.7 smoke)
1. `attention-class requests through PIM: 0` / `AAU fused events: 0` on every run — root cause: `Attention.cc` (the fused op opt-125m / opt-1.3b actually execute) emits 10+ untagged MOVIN/MOVOUT sites, so `request_identity_tagged` never flipped on the hot path.
2. Even after correct tagging, AAU was still energy-only; fused requests round-tripped through DRAM and the simulator couldn't credit cycle savings — AHASD lost to NPU-only on both cycles *and* energy by construction.

## Fix

1. **K/V tagging in `Attention.cc`** (4 MOVIN sites, 2 in `initialize_tiles`, 2 in `initialize_instructions`). Q stays untagged (streaming, not the KV hotspot); attention-output MOVOUT stays untagged (write-back, not memory-bound).
2. **Real AAU bypass** — `PIMBackend::try_aau_bypass` consumes a fused request and Simulator routes it through a new `_pim_bypass_queues[cid]` with `pim_aau_bypass_ns` (default 18 ns ≈ 18 NPU cycles) latency, pushing the completion back into ICNT *without* touching DRAM. Non-fused traffic falls back to the existing `on_dram_push` GTSU/TVC hold path.
3. **Two new overlays** (`pim_only.json`, `ahasd_noaau.json`) — the B2.7 A-axes are now canonical presets, so D1's 4-config sweep can drop straight into `run_baseline.py`.

## Validation

**opt-125m × 4 axes (smoke_p4_g8_2req, parametric, max_k=8):**

| axis | cycles | energy_mJ | aau_fused |
|------|--------|-----------|-----------|
| npu_only | 6,286,808 | 157.31 | 0 |
| pim_only | 6,260,825 | 182.62 | 58,368 |
| ahasd_noaau | 6,282,735 | 187.32 | 0 |
| ahasd_full | 6,263,435 | 182.62 | 58,368 |

- AAU bypass works: `ahasd_full − ahasd_noaau = −19K cycles / −4.7 mJ`
- EDC/TVC/GTSU alone adds no cycle win on this model (attention is compute-bound, not memory-bound)

**opt-125m → opt-1.3b probe (p16/g32/1req, max_k=8):**

| axis | cycles | energy_mJ | aau_fused |
|------|--------|-----------|-----------|
| npu_only | 24,344,199 | 638.19 | 0 |
| ahasd_full | 24,318,782 | 717.61 | 538,672 |

AAU events scale linearly with attention work (10×). Architecture path is sound.

## Honest limitation

- `pim_aau_bypass_ns=18` is the only knob with meaningful cycle leverage; values < 10 start to trivialize memory accounting, > 50 kill the win. Modeling choice documented in `SimulationConfig.h`.
- Mini-bench at `opt-1.3b / gen=32 / 1 request` is NOT yet memory-bound enough to reproduce the paper's 1.8-2.0× speedup vs SpecPIM. That verification moves to D1's full matrix (`opt-6.7b`, `gen ≥ 128`, multi-request).
- PIM's fixed leak+active energy exceeds AAU savings on tiny workloads; expected to invert on D1's larger matrix.

Closes #15.

## Test plan

- [x] `Attention.cc` K/V MOVINs flip `request_identity_tagged=true`
- [x] opt-125m smoke: `attention_class_requests > 0`, `aau_fused > 0`
- [x] All 4 B2.7 axes run through `run_baseline.py` with committed overlays
- [x] `ahasd_full − ahasd_noaau` cycle/energy delta points the right direction
- [x] opt-1.3b probe: AAU event count scales 10× with attention size

Made with [Cursor](https://cursor.com)