### PR TITLE
[feat]: D1 Section 5.2 ablation matrix infra + opt-125m pilot

### DIFF
--- a/configs/baselines/ahasd_aau.json
+++ b/configs/baselines/ahasd_aau.json
@@ -1,0 +1,16 @@
+{
+  "_doc": "D1 ablation stop #2 — 'NPU+PIM+AAU' column of Section 5.2 (Fig 8). GTSU + AAU fusion are on; EDC and TVC are off. This isolates AAU's contribution when task-level async is already in place.",
+  "_inherits": "_base_systolic_c4_128x128_hbm2.json",
+  "enable_ahasd": true,
+  "enable_edc": false,
+  "enable_tvc": false,
+  "enable_aau": true,
+  "max_draft_length": 4,
+  "pim_enable": true,
+  "pim_channel_mask": "",
+  "pim_channel_stride": 2,
+  "pim_clock_mhz": 800,
+  "pim_enable_aau_fusion": true,
+  "pim_aau_fusion_ratio": 0.75,
+  "pim_gtsu_switch_ns": 55
+}

--- a/configs/baselines/ahasd_aau_edc.json
+++ b/configs/baselines/ahasd_aau_edc.json
@@ -1,0 +1,16 @@
+{
+  "_doc": "D1 ablation stop #3 — 'NPU+PIM+AAU+EDC' column of Section 5.2 (Fig 8). GTSU + AAU + EDC are on; TVC is still off. This isolates EDC's contribution on top of the AAU+async baseline.",
+  "_inherits": "_base_systolic_c4_128x128_hbm2.json",
+  "enable_ahasd": true,
+  "enable_edc": true,
+  "enable_tvc": false,
+  "enable_aau": true,
+  "max_draft_length": 4,
+  "pim_enable": true,
+  "pim_channel_mask": "",
+  "pim_channel_stride": 2,
+  "pim_clock_mhz": 800,
+  "pim_enable_aau_fusion": true,
+  "pim_aau_fusion_ratio": 0.75,
+  "pim_gtsu_switch_ns": 55
+}

--- a/configs/baselines/ahasd_none.json
+++ b/configs/baselines/ahasd_none.json
@@ -1,0 +1,16 @@
+{
+  "_doc": "D1 ablation anchor — the 'NPU+PIM' column of Section 5.2 (Fig 8). AHASD *scheduling* is on (enable_ahasd=true so GTSU rank-mode switching actually happens, which is what defines task-level async DLM/TLM cohabitation of PIM), but all three adaptive controllers are off: AAU fusion off, EDC off, TVC off. This is the reference point the paper then stacks AAU / EDC / TVC on top of.",
+  "_inherits": "_base_systolic_c4_128x128_hbm2.json",
+  "enable_ahasd": true,
+  "enable_edc": false,
+  "enable_tvc": false,
+  "enable_aau": false,
+  "max_draft_length": 4,
+  "pim_enable": true,
+  "pim_channel_mask": "",
+  "pim_channel_stride": 2,
+  "pim_clock_mhz": 800,
+  "pim_enable_aau_fusion": false,
+  "pim_aau_fusion_ratio": 0.0,
+  "pim_gtsu_switch_ns": 55
+}

--- a/scripts/run_matrix.py
+++ b/scripts/run_matrix.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+D1 — Section 5.2 progressive-ablation matrix runner.
+
+Iterates over (model-pair × algorithm) cells, delegates each cell to
+`run_baseline.py`, and consolidates the per-cell `metrics.json` into a
+single `matrix.csv` + `matrix.json` under the output directory.
+
+Example:
+
+    scripts/run_matrix.py \\
+        --model-pairs opt-125m:opt-125m-t \\
+        --algorithms ahasd_none,ahasd_aau,ahasd_aau_edc,ahasd_full \\
+        --workload-trace workloads/smoke_p4_g8_2req.csv \\
+        --max-draft-length 4 \\
+        --output-dir workflow/runs/d1_pilot
+
+Writes:
+
+    workflow/runs/d1_pilot/
+      <pair>__<algo>/               # forwarded to run_baseline.py
+        onnxim_config.json, models_list.json, log.txt, metrics.json
+      matrix.csv                    # one row per cell
+      matrix.json                   # same data, JSON flavor
+
+The driver is intentionally dumb about timeouts / retries — if a cell
+fails, we record its returncode and keep going. Re-runs of the script
+pick up only cells missing `metrics.json`, so long-running sweeps can
+resume without re-doing completed cells.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent
+
+
+METRIC_COLUMNS = [
+    "sim_finished_cycles",
+    "final_npu_cycle",
+    "final_pim_cycle",
+    "gtsu_stall_cycles",
+    "tvc_hold_cycles",
+    "attention_class_requests",
+    "pim_aau_fused_events",
+    "gtsu_switches",
+    "total_energy_mj",
+    "draft_rounds",
+    "verifies",
+    "acceptance_ratio",
+    "acceptance_samples",
+    "accepted_tokens",
+    "accepted_pct",
+]
+
+
+def cell_dir(root: Path, model_pair: str, algorithm: str) -> Path:
+    safe_pair = model_pair.replace(":", "__").replace("/", "_")
+    return root / f"{safe_pair}__{algorithm}"
+
+
+def run_cell(args, model_pair: str, algorithm: str) -> Dict:
+    out = cell_dir(args.output_dir, model_pair, algorithm)
+    metrics_path = out / "metrics.json"
+    if metrics_path.exists() and not args.force:
+        print(f"[matrix] cache-hit  {model_pair} x {algorithm}  ({out})")
+        return json.loads(metrics_path.read_text())
+    out.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        str(HERE / "run_baseline.py"),
+        "--baseline", algorithm,
+        "--model-pair", model_pair,
+        "--workload-trace", str(args.workload_trace),
+        "--max-draft-length", str(args.max_draft_length),
+        "--accept-seed", str(args.accept_seed),
+        "--output-dir", str(out),
+        "--timeout-s", str(args.cell_timeout_s),
+    ]
+    if args.acceptance_csv:
+        cmd += ["--acceptance-csv", str(args.acceptance_csv)]
+    print(f"[matrix] run  {model_pair} x {algorithm}  -> {out.name}")
+    # Let run_baseline.py write its own log; we just capture final lines
+    # here to flag failures.
+    rc = subprocess.run(cmd).returncode
+    if metrics_path.exists():
+        m = json.loads(metrics_path.read_text())
+    else:
+        m = {"__error": f"run_baseline.py returned rc={rc} without metrics.json"}
+    m["__cell_returncode"] = rc
+    return m
+
+
+def parse_list(arg: str) -> List[str]:
+    return [s.strip() for s in arg.split(",") if s.strip()]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    ap.add_argument("--model-pairs", required=True,
+                    help="Comma-separated draft:target pairs, e.g. "
+                         "'opt-1.3b:opt-6.7b,llama2-7b:llama2-13b'")
+    ap.add_argument("--algorithms", required=True,
+                    help="Comma-separated baseline overlay names")
+    ap.add_argument("--workload-trace", required=True, type=Path)
+    ap.add_argument("--max-draft-length", type=int, default=4)
+    ap.add_argument("--accept-seed", type=int, default=2025)
+    ap.add_argument("--acceptance-csv", type=Path, default=None)
+    ap.add_argument("--output-dir", type=Path, required=True)
+    ap.add_argument("--cell-timeout-s", type=int, default=7200,
+                    help="Per-cell timeout (default 2h; D1 prod cells can run long)")
+    ap.add_argument("--force", action="store_true",
+                    help="Re-run cells even if metrics.json already exists")
+    args = ap.parse_args()
+
+    pairs = parse_list(args.model_pairs)
+    algos = parse_list(args.algorithms)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    rows: List[Dict] = []
+    failures = 0
+    for pair in pairs:
+        for algo in algos:
+            m = run_cell(args, pair, algo)
+            if m.get("__cell_returncode", -1) != 0 or "__error" in m:
+                failures += 1
+            row = {"model_pair": pair, "algorithm": algo}
+            for c in METRIC_COLUMNS:
+                row[c] = m.get(c)
+            row["__cell_returncode"] = m.get("__cell_returncode")
+            rows.append(row)
+
+    csv_path = args.output_dir / "matrix.csv"
+    json_path = args.output_dir / "matrix.json"
+    fields = ["model_pair", "algorithm"] + METRIC_COLUMNS + ["__cell_returncode"]
+    with csv_path.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+    json_path.write_text(json.dumps(rows, indent=2))
+
+    print()
+    print(f"[matrix] {len(rows)} cells written to {csv_path}")
+    if failures:
+        print(f"[matrix] WARNING: {failures} cells failed (see per-cell log.txt)",
+              file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workflow/PROGRESS.md
+++ b/workflow/PROGRESS.md
@@ -19,7 +19,7 @@
 | Phase B | 仿真器基线诊断 | ✅ 已完成（结论：需从头重建） |
 | **Phase B2** | **仿真器底座重建（多模型调度器 / 协同仿真 / 能量 / 接受模型 / 端到端冒烟）** | ✅ 已完成 |
 | Phase C | 三条基线实现（NPU-only / SpecPIM / GPU-only） | 🔲 未开始 |
-| Phase D | DAC 版实验数据产出（5.2 / 5.3 / W3 / W9） | 🔲 未开始 |
+| Phase D | DAC 版实验数据产出（5.2 / 5.3 / W3 / W9） | 🚧 D1 infra 就绪，prod 矩阵待跑 |
 | Phase E | 敏感性 + 硬件综合（W2 / W6 / W11） | 🔲 未开始 |
 | Phase F | SSRC 真实集成 + Challenge 3 | 🔲 未开始 |
 | Phase G | AHASPro.md 论文文字全面更新 | 🔲 未开始 |
@@ -400,9 +400,49 @@
 
 ---
 
-## Phase D：SSRC 真实集成
+## Phase D：DAC 实验数据产出（原 Phase D Plan）
 
-### D1 — 最小化侵入集成方案
+### D1 — Section 5.2 消融矩阵 infra + 冒烟
+- **矩阵定义**：3 模型对（OPT-1.3B×6.7B / LLaMA2-7B×13B / PaLM-8B×30B） × 4 progressive 算法点（NPU+PIM / +AAU / +AAU+EDC / +AAU+EDC+TVC = ahasd_full） = 12 cells
+- **infra 就绪（2026-04-21）**：
+  - ✅ 三条新 overlay：`configs/baselines/{ahasd_none, ahasd_aau, ahasd_aau_edc}.json`（所有都 `enable_ahasd=true` 保证 GTSU 在位，符合论文"任务级异步 NPU+PIM"定义）
+  - ✅ 矩阵驱动 `scripts/run_matrix.py`：`--model-pairs a:b,c:d` × `--algorithms x,y,z` 笛卡尔积；按 cell 复用 `run_baseline.py`；resume-able（`metrics.json` 已在就跳过，`--force` 覆盖）；产出 `matrix.{csv,json}`
+- **D1 pilot（opt-125m × 4 算法，smoke_p4_g8_2req, max_k=4, 参数化）**：
+
+  | algo | cycles | energy_mJ | gtsu | aau_fused | accept | vs_none |
+  |------|--------|-----------|------|-----------|--------|---------|
+  | ahasd_none | 5,156,573 | 153.50 | 216 | 0 | 0.2353 | 1.000× |
+  | ahasd_aau | 5,155,046 | 149.83 | 216 | 45,792 | 0.2353 | 1.000× |
+  | ahasd_aau_edc | 5,145,056 | 149.81 | 216 | 45,792 | 0.2353 | 1.002× |
+  | ahasd_full | 5,141,793 | 149.81 | 216 | 45,792 | 0.2353 | 1.003× |
+
+  - ✅ progressive ablation **单调改善**（cycles 每加一层都降）
+  - ✅ AAU 引入后 energy 降 2.4%（−3.67 mJ），cycle 只降 0.03% —— 能量比 cycle 更敏感
+  - ⚠️ accept_ratio 四条轴完全一致（0.2353）—— 说明这个 workload/seed 下 EDC 还没差异化 draft length；D1 prod 需要更大 workload + 更复杂 acceptance 参数才能让 EDC 的 k-selection 显效
+- **prod 矩阵状态**：
+  - **不在本期会话里跑**。opt-1.3b×6.7b 单 cell 估计 30-60 min，12 cells = 6-12 h 墙钟。已把 infra 入库，随时可以 `python3 scripts/run_matrix.py --model-pairs opt-1.3b:opt-6.7b,llama2-7b:llama2-13b,palm-8b:palm-30b --algorithms ahasd_none,ahasd_aau,ahasd_aau_edc,ahasd_full ...` 一把起
+  - 需要先创 `workloads/d1_prod_p64_g128_8req.csv`（或类似"真 benchmark 体量"workload）；pilot workload 太小不足以暴露 EDC/TVC 的差异
+- **状态**：✅ infra 完成；🔲 prod 矩阵待用户决策是否本地或远程长跑
+- **产物**：
+  - `configs/baselines/{ahasd_none,ahasd_aau,ahasd_aau_edc}.json`
+  - `scripts/run_matrix.py`
+  - `workflow/runs/d1_pilot_opt125m/{matrix.csv, matrix.json, <pair>__<algo>/*}`
+
+### D2 — Section 5.3 SOTA 对比
+- **输入**：C3 的四列 overlay（npu_only / gpu_only / specpim / ahasd_full） × 3 模型对
+- **状态**：🔲 等 D1 prod 矩阵跑完后一起跑（可共用 `run_matrix.py`）
+
+### D3 — W3 NPU/PIM 利用率分解图
+- **状态**：🔲 未开始
+
+### D4 — W9 overlap 带宽利用率图
+- **状态**：🔲 未开始
+
+---
+
+## Phase F：SSRC 真实集成
+
+### F1 — 最小化侵入集成方案（原 D1 SSRC plan）
 - **原则**：在 PIMSimulator 请求入口加 SSRC gate，deferred 的 batch 不提交 KV cache write 请求，直接减少 PIM 访存周期
 - **验收标准**：`ahasd_cycle_coupling_active=1` 且 SSRC 配置 vs 无 SSRC 的 `total_cycles` 有可测量差异
 - **状态**：🔲 未开始
@@ -450,3 +490,4 @@
 | 2026-04-21 | C1.5 完成（issue #15）：`Attention.cc` K/V MOVIN 补 `request_identity_tagged`（修复 "AAU 全程不触发" 的隐藏 bug），`PIMBackend::try_aau_bypass` + `_pim_bypass_queues` 让融合命中的请求完全绕过 DRAM（`pim_aau_bypass_ns=18`），新增 `pim_only` / `ahasd_noaau` overlay；opt-125m × 4 轴验证 AAU 事件从 0 跃到 58K、`ahasd_full - ahasd_noaau = -19K cycles / -4.7 mJ`；opt-1.3b probe 事件 10× 放大（45K→538K），但 p16/g32 规模仍不足以显 speedup — speedup 验收下沉到 D1 大 workload |
 | 2026-04-21 | C2 完成（issue #17）：`SpecDecodeScheduler::request_rank_switch` 加 `if (_ahasd == nullptr) return;` 门控，把 GTSU 定义为 AHASD-only 机制（pim_only 不再付 GTSU 周期，与 SpecPIM 论文静态通道分配语义一致）；新 overlay `configs/baselines/specpim.json` 作为 W4 SOTA 对比参考；冒烟 4 轴确认 pim_only/specpim GTSU switches 从 216 降到 0，ahasd_full 仍保留 216 次（回归守门） |
 | 2026-04-21 | C3 完成（issue #19）：overlay-only 的 GPU-only proxy —— 放大 DRAM 子系统（`dram_channels` 16→32、`dram_freq` 800→1600，HBM3-class），不动核数/拓扑；第 4 列 SOTA 入位。冒烟 `gpu_only` 对 `npu_only` 1.926×，对 `specpim` 1.926×；`ahasd_full` 对 `specpim` 仅 1.001× —— 论文 1.8-2× speedup claim 确认只能在 D1/D2 大 workload 里验收，此处作为规模依据记录 |
+| 2026-04-21 | D1 infra 完成（issue #21）：新增 `ahasd_none/ahasd_aau/ahasd_aau_edc` progressive overlays + `scripts/run_matrix.py` 笛卡尔积 + resume 驱动；opt-125m pilot 四轴 cycles 单调改善 5.157M → 5.142M，energy 153.50 → 149.81 mJ；prod 12-cell 大矩阵（opt-1.3b×6.7b + llama2 + palm，估 6-12 h 墙钟）入库待跑 |


### PR DESCRIPTION
## Goal

Land the driver + overlays for AHASPro.md Section 5.2 progressive ablation (Fig 8). Prod runs on opt-1.3b×6.7b / LLaMA2 / PaLM are deferred — this PR only commits infra.

## What's in

### Three progressive overlays
All have \`enable_ahasd=true\` so GTSU stays active (what the paper calls \"task-level async NPU+PIM\"):

| overlay | AAU | EDC | TVC | Fig 8 column |
|---------|-----|-----|-----|--------------|
| \`ahasd_none.json\` | ❌ | ❌ | ❌ | NPU+PIM |
| \`ahasd_aau.json\` | ✅ | ❌ | ❌ | +AAU |
| \`ahasd_aau_edc.json\` | ✅ | ✅ | ❌ | +AAU+EDC |
| \`ahasd_full.json\` (existing) | ✅ | ✅ | ✅ | +AAU+EDC+TVC |

### Driver: \`scripts/run_matrix.py\`

Cartesian product of \`--model-pairs a:b,c:d\` × \`--algorithms w,x,y,z\`, forwards each cell to \`run_baseline.py\`. Produces \`matrix.csv\` + \`matrix.json\` with 15 metric columns per cell. Resume-able: re-run skips cells whose \`metrics.json\` already exists (use \`--force\` to rerun).

## D1 Pilot Result

opt-125m × opt-125m-t, smoke_p4_g8_2req, max_k=4, parametric:

| algo | cycles | energy_mJ | gtsu | aau_fused | accept | vs_none |
|------|--------|-----------|------|-----------|--------|---------|
| ahasd_none | 5,156,573 | 153.50 | 216 | 0 | 0.2353 | 1.000× |
| ahasd_aau | 5,155,046 | 149.83 | 216 | 45,792 | 0.2353 | 1.000× |
| ahasd_aau_edc | 5,145,056 | 149.81 | 216 | 45,792 | 0.2353 | 1.002× |
| ahasd_full | 5,141,793 | 149.81 | 216 | 45,792 | 0.2353 | 1.003× |

- ✅ Monotonic cycle improvement across the progression
- ✅ AAU saves 2.4% energy (−3.67 mJ) at near-zero cycle cost
- ⚠️ accept_ratio is identical across all 4 axes — EDC's k-selection isn't differentiating on this tiny workload. Prod matrix needs opt-1.3b+ with a real benchmark trace to exercise EDC.

## Honest scope note

The full 12-cell prod matrix (3 model pairs × 4 algorithms) is estimated at 6-12 hours wall-clock on this host and is **not** run inside this PR. Kick-off command for whoever picks it up:

\`\`\`bash
python3 scripts/run_matrix.py \\
  --model-pairs opt-1.3b:opt-6.7b,llama2-7b:llama2-13b,palm-8b:palm-30b \\
  --algorithms ahasd_none,ahasd_aau,ahasd_aau_edc,ahasd_full \\
  --workload-trace workloads/d1_prod_<TBD>.csv \\
  --max-draft-length 4 \\
  --output-dir workflow/runs/d1_prod \\
  --cell-timeout-s 7200
\`\`\`

A real benchmark-size workload CSV still needs to land before prod can start (tracked as follow-up).

Closes #21.

## Test plan

- [x] All three new overlays load via \`run_baseline.py\`
- [x] Pilot matrix writes \`matrix.csv\` / \`matrix.json\` successfully
- [x] Progressive ablation is monotonic on cycles + energy
- [x] \`--force\` re-runs completed cells; absence of flag skips them

Made with [Cursor](https://cursor.com)