### PR TITLE
[feat]: E1 — W2 sensitivity-sweep infra (EDC + TVC hyperparameters) (#29)

### DIFF
--- a/ONNXim/src/AHASDIntegration.h
+++ b/ONNXim/src/AHASDIntegration.h
@@ -39,16 +39,26 @@ struct AHASDConfig {
   uint32_t max_draft_length = 16;
   uint32_t min_preverify_length = 2;
   uint32_t pre_verify_max = 8;
+  // E1 — sensitivity sweep hyperparameters. Defaults reproduce the
+  // DAC design point (LEHT=8, LLR=3b, H_max=10.0, TVC window=4).
+  float    edc_h_max      = DEFAULT_H_MAX;
+  uint32_t edc_leht_size  = DEFAULT_LEHT_SIZE;
+  uint32_t edc_llr_bits   = DEFAULT_LLR_BITS;
+  uint32_t tvc_cycle_table_size = DEFAULT_CYCLE_TABLE_SIZE;
 };
 
 class AHASDIntegration {
  public:
   explicit AHASDIntegration(const AHASDConfig& cfg) : config_(cfg) {
     if (config_.enable_edc) {
-      edc_ = std::make_unique<EDC>();
+      edc_ = std::make_unique<EDC>(config_.edc_h_max,
+                                   config_.edc_leht_size,
+                                   config_.edc_llr_bits);
     }
     if (config_.enable_tvc) {
-      tvc_ = std::make_unique<TVC>(config_.pim_freq_mhz, config_.npu_freq_mhz);
+      tvc_ = std::make_unique<TVC>(config_.pim_freq_mhz,
+                                   config_.npu_freq_mhz,
+                                   config_.tvc_cycle_table_size);
     }
   }
 

--- a/ONNXim/src/Common.cc
+++ b/ONNXim/src/Common.cc
@@ -144,6 +144,17 @@ SimulationConfig initialize_config(json config) {
     parsed_config.enable_aau = config["enable_aau"];
   if (config.contains("max_draft_length"))
     parsed_config.max_draft_length = config["max_draft_length"];
+  /* E1 — W2 sensitivity-sweep hyperparameters (all optional; omitting a
+   * key reproduces the DAC design point bit-identically).
+   */
+  if (config.contains("edc_h_max"))
+    parsed_config.edc_h_max = config["edc_h_max"];
+  if (config.contains("edc_leht_size"))
+    parsed_config.edc_leht_size = config["edc_leht_size"];
+  if (config.contains("edc_llr_bits"))
+    parsed_config.edc_llr_bits = config["edc_llr_bits"];
+  if (config.contains("tvc_cycle_table_size"))
+    parsed_config.tvc_cycle_table_size = config["tvc_cycle_table_size"];
   // B2.3 — SSRC config keys (enable_ssrc, enable_ssrc_proxy, enable_ssrc_trace,
   // ssrc_state_bytes_per_token, ssrc_resident_limit_bytes,
   // ssrc_confidence_threshold) were removed when the sidecar was deleted.

--- a/ONNXim/src/SimulationConfig.h
+++ b/ONNXim/src/SimulationConfig.h
@@ -79,6 +79,15 @@ struct SimulationConfig {
   bool enable_tvc = true;
   bool enable_aau = true;
   uint32_t max_draft_length = 16;
+  /* E1 — W2 sensitivity-sweep hyperparameters. Defaults reproduce the
+   * DAC design point (LEHT=8, LLR=3b, H_max=10.0, TVC window=4); any
+   * baseline overlay that omits these keys instantiates EDC/TVC
+   * bit-identically to the pre-E1 behaviour.
+   */
+  float    edc_h_max             = 10.0f;
+  uint32_t edc_leht_size         = 8;
+  uint32_t edc_llr_bits          = 3;
+  uint32_t tvc_cycle_table_size  = 4;
 
   /* B2.2 — PIM co-simulation (NPU + PIM heterogeneous DRAM).
    *   pim_enable:          master flag; when false Simulator behaves as legacy.

--- a/ONNXim/src/Simulator.cc
+++ b/ONNXim/src/Simulator.cc
@@ -96,10 +96,18 @@ Simulator::Simulator(SimulationConfig config, bool language_mode)
     ahasd_config.pim_freq_mhz = _config.dram_freq;
     ahasd_config.npu_freq_mhz = _config.core_freq;
     ahasd_config.max_draft_length = _config.max_draft_length;
+    // E1 — W2 sensitivity-sweep hyperparameters.
+    ahasd_config.edc_h_max             = _config.edc_h_max;
+    ahasd_config.edc_leht_size         = _config.edc_leht_size;
+    ahasd_config.edc_llr_bits          = _config.edc_llr_bits;
+    ahasd_config.tvc_cycle_table_size  = _config.tvc_cycle_table_size;
     _ahasd = std::make_unique<AHASD::AHASDIntegration>(ahasd_config);
-    spdlog::info("[AHASD] Enabled - EDC:{} TVC:{} AAU:{} max_k={}",
+    spdlog::info("[AHASD] Enabled - EDC:{} TVC:{} AAU:{} max_k={} "
+                 "edc(H_max={:.2f} LEHT={} LLR={}b) tvc_window={}",
                  ahasd_config.enable_edc, ahasd_config.enable_tvc,
-                 ahasd_config.enable_aau, ahasd_config.max_draft_length);
+                 ahasd_config.enable_aau, ahasd_config.max_draft_length,
+                 ahasd_config.edc_h_max, ahasd_config.edc_leht_size,
+                 ahasd_config.edc_llr_bits, ahasd_config.tvc_cycle_table_size);
     if (_enable_ahasd && !(_cosim && _cosim->is_active())) {
       spdlog::warn("[AHASD] enabled without PIM co-sim: GTSU stalls and AAU "
                     "fusion accounting will be inert; EDC/TVC decisions still "

--- a/ONNXim/src/async_queue/EDC.h
+++ b/ONNXim/src/async_queue/EDC.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <cstdint>
 #include <cmath>
+#include <algorithm>
 #include "../Common.h"
 
 // Entropy-History-Aware Drafting Control (EDC) Module
@@ -11,10 +12,20 @@
 
 namespace AHASD {
 
-constexpr uint32_t LEHT_SIZE = 8;  // Local Entropy History Table size
-constexpr uint32_t PHT_SIZE = 512; // Pattern History Table size (2^9)
-constexpr uint32_t PHT_COUNTER_BITS = 2;  // 2-bit saturating counter
-constexpr float H_MAX = 10.0f;  // Maximum entropy value
+// E1 — sensitivity sweep defaults. These values match the DAC design
+// point; parametric overrides flow from SimulationConfig via
+// AHASDIntegration. Keeping them as the historical constants means
+// zero-config instantiation reproduces the DAC behaviour bit-for-bit.
+constexpr uint32_t DEFAULT_LEHT_SIZE = 8;   // Local Entropy History Table
+constexpr uint32_t DEFAULT_PHT_SIZE  = 512; // Pattern History Table (2^9)
+constexpr uint32_t PHT_COUNTER_BITS  = 2;   // 2-bit saturating counter
+constexpr float    DEFAULT_H_MAX     = 10.0f;
+constexpr uint32_t DEFAULT_LLR_BITS  = 3;
+
+// Back-compat aliases (referenced in older call sites / tests).
+constexpr uint32_t LEHT_SIZE         = DEFAULT_LEHT_SIZE;
+constexpr uint32_t PHT_SIZE          = DEFAULT_PHT_SIZE;
+constexpr float    H_MAX             = DEFAULT_H_MAX;
 
 // 2-bit saturating counter states
 enum class CounterState : uint8_t {
@@ -28,26 +39,44 @@ class EDC {
 private:
     // Local Entropy History Table (LEHT) - stores recent entropy buckets
     std::vector<uint8_t> leht_;
-    
+
     // Local Commit Entropy History Table (LCEHT) - stores verified entropy
     std::vector<uint8_t> lceht_;
-    
-    // Leading Length Register (LLR) - 3-bit counter
+
+    // Leading Length Register (LLR) - n-bit counter (default 3)
     uint8_t llr_;
-    
-    // Pattern History Table (PHT) - 512 entries with 2-bit counters
+
+    // Pattern History Table (PHT) - sized from LEHT/LLR
     std::vector<CounterState> pht_;
-    
+
     // Statistics
     uint64_t total_predictions_;
     uint64_t correct_predictions_;
     uint64_t suppressed_drafts_;
     uint64_t total_drafts_;
-    
-    // Configuration
+
+    // Configuration (E1 — runtime-configurable)
     float h_max_;
-    uint32_t leht_ptr_;  // Circular buffer pointer
-    
+    uint32_t leht_size_;
+    uint32_t llr_bits_;
+    uint8_t  llr_max_;          // (1 << llr_bits_) - 1
+    uint32_t pht_size_;         // cached, power-of-two
+    uint32_t pht_index_mask_;   // pht_size_ - 1
+    uint32_t leht_group_bits_;  // bits per LEHT-avg field in PHT index
+    uint32_t leht_ptr_;         // Circular buffer pointer
+
+    // Helper: derive PHT sizing from LEHT/LLR. PHT index historically =
+    // {avg(H_{4-7})[2:0], avg(H_{0-3})[2:0], LLR[2:0]} = 9 bits -> 512.
+    // Generalisation: keep 3-bit entropy bucket encoding (entropy_to_bucket
+    // always yields [0,7]), so each LEHT-avg contributes 3 bits regardless
+    // of history length; LLR contributes llr_bits_. Cap at 16 bits (64 KiB)
+    // to avoid pathological configs.
+    static uint32_t compute_pht_size(uint32_t llr_bits) {
+        uint32_t bits = 3u + 3u + llr_bits;  // two LEHT-avgs + LLR
+        bits = std::min<uint32_t>(bits, 16u);
+        return 1u << bits;
+    }
+
     // Helper functions
     uint8_t entropy_to_bucket(float entropy) const {
         // Map entropy to one of 8 buckets [0,7]
@@ -55,30 +84,37 @@ private:
         if (entropy > h_max_) entropy = h_max_;
         return static_cast<uint8_t>((entropy / h_max_) * 7.99f);
     }
-    
+
     uint16_t calculate_pht_index() const {
         // Calculate PHT index from LEHT groups and LLR
-        // Input_PHT = {avg(H_{4-7}), avg(H_{0-3}), LLR}
-        
-        // Group 1: H_{0-3}
+        // Input_PHT = {avg(upper half), avg(lower half), LLR}
+        if (leht_size_ == 0) return 0;
+        uint32_t half = std::max<uint32_t>(1u, leht_size_ / 2u);
+
+        // Lower half
         uint32_t sum_low = 0;
-        for (uint32_t i = 0; i < 4; i++) {
+        for (uint32_t i = 0; i < half && i < leht_size_; i++) {
             sum_low += leht_[i];
         }
-        uint8_t avg_low = sum_low / 4;  // 3 bits
-        
-        // Group 2: H_{4-7}
+        uint8_t avg_low = static_cast<uint8_t>(sum_low / half);  // 3 bits
+
+        // Upper half (may be shorter for odd leht_size_)
+        uint32_t upper_count = leht_size_ > half ? (leht_size_ - half) : 0;
         uint32_t sum_high = 0;
-        for (uint32_t i = 4; i < 8; i++) {
+        for (uint32_t i = half; i < leht_size_; i++) {
             sum_high += leht_[i];
         }
-        uint8_t avg_high = sum_high / 4;  // 3 bits
-        
-        // Concatenate: {avg_high[2:0], avg_low[2:0], llr[2:0]} = 9 bits
-        uint16_t index = (avg_high << 6) | (avg_low << 3) | llr_;
-        return index & 0x1FF;  // Ensure 9-bit
+        uint8_t avg_high = upper_count
+            ? static_cast<uint8_t>(sum_high / upper_count)
+            : 0;
+
+        // Concatenate: {avg_high[2:0], avg_low[2:0], llr[llr_bits_-1:0]}
+        uint32_t index = (static_cast<uint32_t>(avg_high) << (3u + llr_bits_))
+                       | (static_cast<uint32_t>(avg_low)  << llr_bits_)
+                       | static_cast<uint32_t>(llr_ & llr_max_);
+        return static_cast<uint16_t>(index & pht_index_mask_);
     }
-    
+
     void update_counter(CounterState& counter, bool taken) {
         uint8_t val = static_cast<uint8_t>(counter);
         if (taken && val < 3) {
@@ -89,65 +125,70 @@ private:
     }
 
 public:
-    EDC() : llr_(0), h_max_(H_MAX), leht_ptr_(0),
-            total_predictions_(0), correct_predictions_(0),
-            suppressed_drafts_(0), total_drafts_(0) {
-        leht_.resize(LEHT_SIZE, 0);
-        lceht_.resize(LEHT_SIZE, 0);
-        pht_.resize(PHT_SIZE, CounterState::WEAKLY_TAKEN);
+    EDC(float h_max = DEFAULT_H_MAX,
+        uint32_t leht_size = DEFAULT_LEHT_SIZE,
+        uint32_t llr_bits  = DEFAULT_LLR_BITS)
+        : llr_(0),
+          total_predictions_(0), correct_predictions_(0),
+          suppressed_drafts_(0), total_drafts_(0),
+          h_max_(h_max),
+          leht_size_(std::max<uint32_t>(1u, leht_size)),
+          llr_bits_(std::clamp<uint32_t>(llr_bits, 1u, 8u)),
+          llr_max_(static_cast<uint8_t>((1u << std::clamp<uint32_t>(llr_bits, 1u, 8u)) - 1u)),
+          pht_size_(compute_pht_size(std::clamp<uint32_t>(llr_bits, 1u, 8u))),
+          pht_index_mask_(pht_size_ - 1u),
+          leht_group_bits_(3u),
+          leht_ptr_(0) {
+        leht_.resize(leht_size_, 0);
+        lceht_.resize(leht_size_, 0);
+        pht_.resize(pht_size_, CounterState::WEAKLY_TAKEN);
     }
-    
+
     // Called after each draft batch generation
     bool should_continue_drafting(float avg_entropy) {
         total_drafts_++;
-        
-        // Map entropy to bucket and update LEHT
+
         uint8_t bucket = entropy_to_bucket(avg_entropy);
         leht_[leht_ptr_] = bucket;
-        leht_ptr_ = (leht_ptr_ + 1) % LEHT_SIZE;
-        
-        // Increment LLR (3-bit, saturates at 7)
-        if (llr_ < 7) {
+        leht_ptr_ = (leht_ptr_ + 1) % leht_size_;
+
+        // Increment LLR (saturates at llr_max_)
+        if (llr_ < llr_max_) {
             llr_++;
         }
-        
-        // Calculate PHT index and make prediction
+
         uint16_t pht_index = calculate_pht_index();
         CounterState prediction = pht_[pht_index];
-        
+
         total_predictions_++;
-        
+
         // MSB of counter determines prediction
         bool should_continue = (static_cast<uint8_t>(prediction) >= 2);
-        
+
         if (!should_continue) {
             suppressed_drafts_++;
         }
-        
+
         return should_continue;
     }
-    
+
     // Called after NPU verification completes
     void update_on_verification(bool fully_accepted, uint32_t accepted_count) {
-        // Decrement LLR
         if (llr_ > 0) {
             llr_--;
         }
-        
-        // If accepted, commit LEHT to LCEHT
+
         if (fully_accepted) {
             lceht_ = leht_;
             correct_predictions_++;
         } else {
-            // Rollback: restore LEHT from LCEHT
             leht_ = lceht_;
         }
-        
-        // Update PHT based on verification result
+
         uint16_t pht_index = calculate_pht_index();
         update_counter(pht_[pht_index], fully_accepted);
     }
-    
+
     // Reset state (for new inference sequence)
     void reset() {
         std::fill(leht_.begin(), leht_.end(), 0);
@@ -155,45 +196,44 @@ public:
         llr_ = 0;
         leht_ptr_ = 0;
     }
-    
+
     // Getters for current state
     uint8_t get_llr() const { return llr_; }
-    
+
     const std::vector<uint8_t>& get_leht() const { return leht_; }
-    
+
+    float    get_h_max() const { return h_max_; }
+    uint32_t get_leht_size() const { return leht_size_; }
+    uint32_t get_llr_bits() const { return llr_bits_; }
+    uint32_t get_pht_size() const { return pht_size_; }
+
     // Statistics
     double get_prediction_accuracy() const {
         if (total_predictions_ == 0) return 0.0;
         return static_cast<double>(correct_predictions_) / total_predictions_;
     }
-    
+
     double get_suppression_rate() const {
         if (total_drafts_ == 0) return 0.0;
         return static_cast<double>(suppressed_drafts_) / total_drafts_;
     }
-    
+
     void print_statistics() const {
         spdlog::info("=== EDC Statistics ===");
+        spdlog::info("Config: H_max={:.2f} LEHT_size={} LLR_bits={} PHT_size={}",
+                     h_max_, leht_size_, llr_bits_, pht_size_);
         spdlog::info("Total Predictions: {}, Accuracy: {:.2f}%",
                     total_predictions_, get_prediction_accuracy() * 100.0);
         spdlog::info("Total Drafts: {}, Suppressed: {} ({:.2f}%)",
-                    total_drafts_, suppressed_drafts_, 
+                    total_drafts_, suppressed_drafts_,
                     get_suppression_rate() * 100.0);
         spdlog::info("Current LLR: {}", llr_);
-        
-        // Print LEHT state
-        spdlog::info("LEHT: [{}, {}, {}, {}, {}, {}, {}, {}]",
-                    leht_[0], leht_[1], leht_[2], leht_[3],
-                    leht_[4], leht_[5], leht_[6], leht_[7]);
     }
-    
+
     // Hardware cost estimation (for paper)
     static constexpr size_t get_area_bits() {
-        // LEHT: 8 entries × 3 bits = 24 bits
-        // LCEHT: 8 entries × 3 bits = 24 bits
-        // LLR: 3 bits
-        // PHT: 512 entries × 2 bits = 1024 bits
-        // Total: ~1075 bits ≈ 135 bytes
+        // Reported at the DAC design point (LEHT=8, LLR=3b, PHT=512) so
+        // Section 5.4 numbers remain stable regardless of sweep configs.
         return 24 + 24 + 3 + 1024;
     }
 };

--- a/ONNXim/src/async_queue/TVC.h
+++ b/ONNXim/src/async_queue/TVC.h
@@ -11,7 +11,10 @@
 
 namespace AHASD {
 
-constexpr uint32_t CYCLE_TABLE_SIZE = 4;  // Keep last 4 samples for moving average
+// E1 — sensitivity sweep default. Historical value is 4; parametric
+// overrides flow from SimulationConfig via AHASDIntegration.
+constexpr uint32_t DEFAULT_CYCLE_TABLE_SIZE = 4;
+constexpr uint32_t CYCLE_TABLE_SIZE = DEFAULT_CYCLE_TABLE_SIZE;  // back-compat
 
 struct CycleRecord {
     uint64_t cycles;
@@ -45,40 +48,47 @@ private:
     
     // Frequency ratio (PIM freq / NPU freq) for cycle conversion
     float freq_ratio_;
-    
+
+    // E1 — runtime-configurable sliding window depth (NVCT/PDCT/PVCT share).
+    uint32_t cycle_table_size_;
+
     // Statistics
     uint64_t total_preverifications_;
     uint64_t successful_preverifications_;
     uint64_t prevented_npu_idles_;
     uint64_t total_decisions_;
-    
+
     // Helper: Calculate moving average of cycle ratios
     float calculate_avg_ratio(const std::deque<CycleRecord>& table) const {
         if (table.empty()) return 0.0f;
-        
+
         float sum = 0.0f;
         for (const auto& record : table) {
             sum += record.get_ratio();
         }
         return sum / table.size();
     }
-    
+
     // Helper: Add record to cycle table (maintain size limit)
-    void add_to_table(std::deque<CycleRecord>& table, 
+    void add_to_table(std::deque<CycleRecord>& table,
                      uint64_t cycles, uint32_t length) {
-        if (table.size() >= CYCLE_TABLE_SIZE) {
+        while (table.size() >= cycle_table_size_) {
             table.pop_front();
         }
         table.push_back(CycleRecord(cycles, length));
     }
 
 public:
-    TVC(float pim_freq_mhz = 800.0f, float npu_freq_mhz = 1000.0f) 
-        : ncr_(0), npu_task_start_(0), 
+    TVC(float pim_freq_mhz = 800.0f, float npu_freq_mhz = 1000.0f,
+        uint32_t cycle_table_size = DEFAULT_CYCLE_TABLE_SIZE)
+        : ncr_(0), npu_task_start_(0),
+          cycle_table_size_(std::max<uint32_t>(1u, cycle_table_size)),
           total_preverifications_(0), successful_preverifications_(0),
           prevented_npu_idles_(0), total_decisions_(0) {
         freq_ratio_ = pim_freq_mhz / npu_freq_mhz;
     }
+
+    uint32_t get_cycle_table_size() const { return cycle_table_size_; }
     
     // Record NPU verification completion
     void record_npu_verification(uint64_t cycles, uint32_t kv_cache_length) {

--- a/scripts/run_baseline.py
+++ b/scripts/run_baseline.py
@@ -155,6 +155,14 @@ def main() -> int:
     ap.add_argument("--onnxim", type=Path, default=REPO / "ONNXim")
     ap.add_argument("--output-dir", type=Path, required=True)
     ap.add_argument("--timeout-s", type=int, default=600)
+    # E1 — allow sensitivity sweeps to override individual SimulationConfig
+    # keys without duplicating the whole overlay. Repeatable, last wins.
+    # Values are parsed as JSON so ints/floats/bools/lists are preserved.
+    ap.add_argument("--config-override", action="append", default=[],
+                    metavar="KEY=JSON_VALUE",
+                    help="Override a single SimulationConfig key after the "
+                         "overlay merge, e.g. --config-override edc_h_max=8.0. "
+                         "Repeatable; JSON-parsed.")
     args = ap.parse_args()
 
     out_dir = args.output_dir.resolve()
@@ -163,6 +171,15 @@ def main() -> int:
     cfg = resolve_overlay(args.baseline)
     cfg["max_draft_length"] = args.max_draft_length
     cfg["accept_rng_seed"] = args.accept_seed
+    for spec in args.config_override:
+        if "=" not in spec:
+            raise SystemExit(f"[baseline] --config-override must be KEY=JSON_VALUE, got {spec!r}")
+        key, _, raw = spec.partition("=")
+        try:
+            value = json.loads(raw)
+        except json.JSONDecodeError:
+            value = raw
+        cfg[key] = value
     if args.acceptance_csv:
         cfg["accept_mode"] = "trace_replay"
         cfg["accept_trace_path"] = str(args.acceptance_csv.resolve())

--- a/scripts/run_sensitivity.py
+++ b/scripts/run_sensitivity.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+E1 — W2 sensitivity-sweep driver.
+
+Runs four axes of hyperparameter sweeps over the `ahasd_full` baseline
+on a single model pair and workload, collecting throughput, acceptance
+ratio, and NPU memory-idle % per cell.
+
+Axes (match `workflow/AHASDFix.md` W2 plan):
+
+  EDC — H_max            {10.0, 8.0, 7.0, 6.0}   (max / P95 / P90 / mean+2σ)
+  EDC — LEHT history     {4, 8, 12, 16}
+  EDC — LLR bit width    {2, 3, 4}
+  TVC — cycle table size {1, 2, 4, 8}
+
+Each cell is a single invocation of `run_baseline.py --baseline ahasd_full
+--config-override <axis>=<value>`. The driver parses the resulting
+`metrics.json` plus `utilization.json` (produced by D3's parser if the
+run_matrix hook is in use; recomputed here if missing) and consolidates
+into `sensitivity_results.json`:
+
+    {
+      "model_pair": "opt-125m:opt-125m-t",
+      "workload": "/abs/path/to/workloads/smoke_p4_g8_2req.csv",
+      "cells": [
+        {
+          "axis": "edc_h_max", "value": 10.0,
+          "sim_finished_cycles": 5141793,
+          "tokens_completed": ...,           # from acceptance_samples × accept_pct
+          "throughput_tokens_per_mcycle": ...,
+          "acceptance_ratio": 0.2353,
+          "npu_memory_idle_pct": 75.17,
+          "total_energy_mj": 149.81
+        },
+        ...
+      ]
+    }
+
+Designed to be re-runnable: existing cells with valid `metrics.json`
+short-circuit via `run_baseline.py`'s own caching path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent
+
+# Ensure D3 parser is importable so we can compute utilization.json if
+# the cell didn't go through run_matrix.
+sys.path.insert(0, str(HERE))
+from parse_utilization import parse_log as _parse_util_log  # type: ignore
+
+
+# Default axes (match W2 plan).
+DEFAULT_AXES: Dict[str, List] = {
+    "edc_h_max":            [10.0, 8.0, 7.0, 6.0],
+    "edc_leht_size":        [4, 8, 12, 16],
+    "edc_llr_bits":         [2, 3, 4],
+    "tvc_cycle_table_size": [1, 2, 4, 8],
+}
+
+
+def cell_dir(root: Path, axis: str, value) -> Path:
+    # JSON-safe, filesystem-safe suffix.
+    safe = str(value).replace(".", "p").replace("-", "neg")
+    return root / f"{axis}__{safe}"
+
+
+def run_cell(args, axis: str, value) -> Dict:
+    out = cell_dir(args.output_dir, axis, value)
+    metrics_path = out / "metrics.json"
+    if metrics_path.exists() and not args.force:
+        print(f"[sensitivity] cache-hit  {axis}={value}  ({out})")
+        m = json.loads(metrics_path.read_text())
+    else:
+        out.mkdir(parents=True, exist_ok=True)
+        cmd = [
+            sys.executable, str(HERE / "run_baseline.py"),
+            "--baseline", "ahasd_full",
+            "--model-pair", args.model_pair,
+            "--workload-trace", str(args.workload_trace),
+            "--max-draft-length", str(args.max_draft_length),
+            "--accept-seed", str(args.accept_seed),
+            "--output-dir", str(out),
+            "--timeout-s", str(args.cell_timeout_s),
+            "--config-override", f"{axis}={json.dumps(value)}",
+        ]
+        print(f"[sensitivity] run  {axis}={value}  -> {out.name}")
+        rc = subprocess.run(cmd).returncode
+        if metrics_path.exists():
+            m = json.loads(metrics_path.read_text())
+        else:
+            m = {"__error": f"run_baseline rc={rc} no metrics.json"}
+        m["__cell_returncode"] = rc
+
+    log_path = out / "log.txt"
+    util_path = out / "utilization.json"
+    util: Dict = {}
+    if log_path.exists() and (args.force or not util_path.exists()):
+        try:
+            util = _parse_util_log(log_path)
+            util_path.write_text(json.dumps(util, indent=2))
+        except Exception as exc:  # pragma: no cover
+            print(f"[sensitivity] WARN utilization parse failed for "
+                  f"{axis}={value}: {exc}", file=sys.stderr)
+    elif util_path.exists():
+        util = json.loads(util_path.read_text())
+
+    cycles = m.get("sim_finished_cycles")
+    accept = m.get("acceptance_ratio")
+    samples = m.get("acceptance_samples") or 0
+    # Throughput proxy: "accepted tokens per million simulator cycles".
+    # Matches the shape of Fig W2's Y-axis (relative throughput) without
+    # baking in any particular clock rate.
+    throughput = None
+    accepted_tokens = None
+    if cycles and samples:
+        accepted_tokens = samples * (accept or 0.0)
+        throughput = round(accepted_tokens / (cycles / 1.0e6), 3)
+
+    mem_idle = None
+    if util:
+        mem_idle = util.get("npu_util_pct", {}).get("memory_unit_idle_pct")
+
+    return {
+        "axis": axis, "value": value,
+        "sim_finished_cycles": cycles,
+        "acceptance_ratio": accept,
+        "acceptance_samples": samples,
+        "accepted_tokens": accepted_tokens,
+        "throughput_tokens_per_mcycle": throughput,
+        "npu_memory_idle_pct": mem_idle,
+        "total_energy_mj": m.get("total_energy_mj"),
+        "pim_gtsu_stall_cycles": (util.get("pim") or {}).get("gtsu_stall_cycles") if util else None,
+        "cell_returncode": m.get("__cell_returncode"),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    ap.add_argument("--model-pair", default="opt-125m:opt-125m-t")
+    ap.add_argument("--workload-trace", type=Path, required=True)
+    ap.add_argument("--max-draft-length", type=int, default=4)
+    ap.add_argument("--accept-seed", type=int, default=2025)
+    ap.add_argument("--output-dir", type=Path, required=True)
+    ap.add_argument("--cell-timeout-s", type=int, default=600)
+    ap.add_argument("--force", action="store_true",
+                    help="Re-run cells even if metrics.json already exists")
+    ap.add_argument("--axes", default=",".join(DEFAULT_AXES.keys()),
+                    help=f"Comma-separated subset; default all four: "
+                         f"{list(DEFAULT_AXES.keys())}")
+    args = ap.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    selected = [a.strip() for a in args.axes.split(",") if a.strip()]
+    for a in selected:
+        if a not in DEFAULT_AXES:
+            print(f"[sensitivity] unknown axis {a!r}; valid: {list(DEFAULT_AXES)}",
+                  file=sys.stderr)
+            return 2
+
+    cells: List[Dict] = []
+    for axis in selected:
+        for value in DEFAULT_AXES[axis]:
+            cell = run_cell(args, axis, value)
+            cells.append(cell)
+
+    results = {
+        "model_pair": args.model_pair,
+        "workload": str(args.workload_trace.resolve()),
+        "max_draft_length": args.max_draft_length,
+        "axes": {a: DEFAULT_AXES[a] for a in selected},
+        "cells": cells,
+    }
+    (args.output_dir / "sensitivity_results.json").write_text(
+        json.dumps(results, indent=2))
+
+    print()
+    print(f"[sensitivity] {len(cells)} cells -> "
+          f"{args.output_dir / 'sensitivity_results.json'}")
+    # Pretty summary table.
+    print()
+    print(f"{'axis':<24} {'value':>8} {'cycles':>12} {'accept':>8} "
+          f"{'tok/Mc':>8} {'mem_idle%':>10} {'energy':>8}")
+    for c in cells:
+        print(f"{c['axis']:<24} {str(c['value']):>8} "
+              f"{c['sim_finished_cycles'] or '-':>12} "
+              f"{c['acceptance_ratio'] or '-':>8} "
+              f"{c['throughput_tokens_per_mcycle'] or '-':>8} "
+              f"{c['npu_memory_idle_pct'] or '-':>10} "
+              f"{c['total_energy_mj'] or '-':>8}")
+    bad = sum(1 for c in cells if c.get("cell_returncode", 0) != 0 and c.get("cell_returncode") is not None)
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Closes #29. Make the four DAC-design-point hyperparameters runtime-configurable, add a driver for the W2 four-axis sweep, and pilot on opt-125m.

## Source changes (ONNXim — rebuild once; defaults reproduce DAC bit-for-bit)
- **\`EDC.h\`**: ctor now accepts \`h_max\`, \`leht_size\`, \`llr_bits\`. PHT is sized dynamically from \`2^(3+3+llr_bits)\` (capped at 16 bits). PHT-index layout generalised to \`{avg_high[2:0], avg_low[2:0], llr[llr_bits-1:0]}\`. Legacy \`LEHT_SIZE / PHT_SIZE / H_MAX\` constants retained as aliases.
- **\`TVC.h\`**: ctor accepts \`cycle_table_size\`; NVCT / PDCT / PVCT share the depth.
- **\`AHASDConfig\` + \`AHASDIntegration\`**: thread the four knobs through.
- **\`SimulationConfig\` + \`Common.cc\`**: four optional JSON keys (\`edc_h_max\`, \`edc_leht_size\`, \`edc_llr_bits\`, \`tvc_cycle_table_size\`) with DAC defaults. Omitting them is a no-op.
- **\`Simulator.cc\`**: log the effective EDC/TVC config at \`[AHASD] Enabled\`.

## Scripts
- **\`run_baseline.py\`**: new \`--config-override KEY=JSON_VALUE\` (repeatable, JSON-parsed). Merges into the resolved overlay right before the simulator config is written. Enables sweeps without duplicating overlays.
- **\`scripts/run_sensitivity.py\`**: four-axis W2 driver against \`ahasd_full\`. Consolidates throughput / acceptance / memory-idle / energy into \`sensitivity_results.json\` with per-cell caching.

## Evidence — opt-125m × 15-cell pilot (\`workflow/runs/e1_pilot/sensitivity_results.json\`)
All 15 cells produce **bit-identical** metrics (cycles 5,149,538 / accept 0.2353 / energy 149.82 mJ / npu_idle 75.21%). Log inspection confirms the simulator is correctly configured per cell:

| evidence | value |
|---|---|
| PHT size for LLR={2,3,4} | 256 / 512 / 1024 |
| EDC total predictions | 47 |
| EDC suppressed drafts | **0 (0.00%)** — PHT stays at WEAKLY_TAKEN |
| TVC total decisions | 17 |
| TVC pre-verifications inserted | **0** |

The adaptive paths simply don't fire — the p4/g8 workload is too small. This matches the C1.5 mini-bench and D1 pilot findings exactly. **W2's trade-off curves need prod workloads (opt-1.3b / llama2-7b with p32/g256).**

## Regression guardrail
\`ahasd_full\` with no overrides lands within ~0.15% of the pre-E1 cached D1 pilot cycles — inside the known ~0.5% run-to-run simulator non-determinism. \`[AHASD] Enabled\` prints the expected default \`H_max=10.00 LEHT=8 LLR=3b tvc_window=4\`.

## Test plan
- [x] Zero-config run matches pre-E1 cached result (±0.15%)
- [x] Per-cell \`[AHASD] Enabled\` reflects the override (LLR=2b / 3b / 4b, PHT resizes 256/512/1024)
- [x] \`sensitivity_results.json\` contains all 15 cells with throughput / acceptance / memory-idle populated
- [ ] Prod sweep on opt-1.3b (deferred to the unified prod-matrix run)

Made with [Cursor](https://cursor.com)